### PR TITLE
If the instance url is set and it is github.com, use a standard client

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -142,7 +142,7 @@ func newGithubClient(ctx context.Context, instanceURL string, accessToken string
 	tc := oauth2.NewClient(ctx, ts)
 
 	instanceURL = strings.TrimSuffix(instanceURL, "/")
-	if instanceURL != "" && instanceURL != "https://github.com" {
+	if instanceURL != "" && instanceURL != githubDotCom {
 		return github.NewEnterpriseClient(instanceURL, instanceURL, tc)
 	}
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -17,6 +17,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+const githubDotCom = "https://github.com"
+
 var ValidAssetDomains = []string{"avatars.githubusercontent.com"}
 
 var (
@@ -139,7 +141,8 @@ func newGithubClient(ctx context.Context, instanceURL string, accessToken string
 	)
 	tc := oauth2.NewClient(ctx, ts)
 
-	if instanceURL != "" {
+	instanceURL = strings.TrimSuffix(instanceURL, "/")
+	if instanceURL != "" && instanceURL != "https://github.com" {
 		return github.NewEnterpriseClient(instanceURL, instanceURL, tc)
 	}
 


### PR DESCRIPTION
Otherwise if you specify an instance url of `https://github.com` the connector will attempt to use an enterprise client resulting in 404s.