### PR TITLE
The github client lib doesn't properly format enterprise graphql urls

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -187,7 +188,14 @@ func newGithubGraphqlClient(ctx context.Context, instanceURL string, accessToken
 
 	instanceURL = strings.TrimSuffix(instanceURL, "/")
 	if instanceURL != "" && instanceURL != githubDotCom {
-		return githubv4.NewEnterpriseClient(instanceURL, httpClient), nil
+		gqlURL, err := url.Parse(instanceURL)
+		if err != nil {
+			return nil, err
+		}
+
+		gqlURL.Path = "/api/graphql"
+
+		return githubv4.NewEnterpriseClient(gqlURL.String(), tc), nil
 	}
 
 	return githubv4.NewClient(tc), nil


### PR DESCRIPTION
When creating a normal client, the `github.NewEnterpriseClient()` method formats the URL accordingly to the proper base URL. The v4 client(that supports gql) uses whatever is passed directly, so we need to append `/api/graphql` to the URL.

See for more details: https://docs.github.com/en/enterprise-server@3.9/graphql/guides/forming-calls-with-graphql