### PR TITLE
When provisioning team or repositories, don't rely on the entitlement slug

### DIFF
--- a/pkg/connector/repository_test.go
+++ b/pkg/connector/repository_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/conductorone/baton-github/test"
-	"github.com/conductorone/baton-github/test/mocks"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
+	entitlement2 "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/google/go-github/v63/github"
 	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-github/test"
+	"github.com/conductorone/baton-github/test/mocks"
 )
 
 func TestRepository(t *testing.T) {
@@ -28,7 +30,10 @@ func TestRepository(t *testing.T) {
 		repository, _ := repositoryResource(ctx, githubRepository, organization.Id)
 		user, _ := userResource(ctx, githubUser, *githubUser.Email, nil)
 
-		entitlement := v2.Entitlement{Resource: repository}
+		entitlement := v2.Entitlement{
+			Id:       entitlement2.NewEntitlementID(repository, "admin"),
+			Resource: repository,
+		}
 
 		grantAnnotations, err := client.Grant(ctx, user, &entitlement)
 		require.Nil(t, err)

--- a/pkg/connector/team.go
+++ b/pkg/connector/team.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -266,13 +267,20 @@ func (o *teamResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 		return nil, fmt.Errorf("github-connectorv2: failed to get user %d, err: %w", userId, err)
 	}
 
+	enIDParts := strings.Split(entitlement.Id, ":")
+	if len(enIDParts) != 3 {
+		return nil, fmt.Errorf("github-connectorv2: invalid entitlement ID: %s", entitlement.Id)
+	}
+	permission := enIDParts[2]
+
 	_, _, e := o.client.Teams.AddTeamMembershipByID(
 		ctx,
 		orgId,
 		teamId,
 		user.GetLogin(),
-		&github.TeamAddTeamMembershipOptions{Role: entitlement.Slug},
+		&github.TeamAddTeamMembershipOptions{Role: permission},
 	)
+
 	if e != nil {
 		return nil, fmt.Errorf("github-connectorv2: failed to add user to a team: %w", e)
 	}

--- a/pkg/connector/team_test.go
+++ b/pkg/connector/team_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/conductorone/baton-github/test"
-	"github.com/conductorone/baton-github/test/mocks"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
+	entitlement2 "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/google/go-github/v63/github"
 	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-github/test"
+	"github.com/conductorone/baton-github/test/mocks"
 )
 
 func TestTeam(t *testing.T) {
@@ -28,7 +30,10 @@ func TestTeam(t *testing.T) {
 		team, _ := teamResource(githubTeam, organization.Id)
 		user, _ := userResource(ctx, githubUser, *githubUser.Email, nil)
 
-		entitlement := v2.Entitlement{Resource: team}
+		entitlement := v2.Entitlement{
+			Id:       entitlement2.NewEntitlementID(team, "member"),
+			Resource: team,
+		}
 
 		grantAnnotations, err := client.Grant(ctx, user, &entitlement)
 		require.Nil(t, err)


### PR DESCRIPTION
Instead we should look at the entitlement ID to figure out which permission to provision. 