### PR TITLE
[BB-614] baton-github: ignore not found error

### DIFF
--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -3,6 +3,7 @@ package connector
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 	"sync"
@@ -211,4 +212,11 @@ type hasSAMLQuery struct {
 			Id string
 		}
 	} `graphql:"organization(login: $orgLoginName)"`
+}
+
+func isNotFoundError(resp *github.Response) bool {
+	if resp == nil {
+		return false
+	}
+	return resp.StatusCode == http.StatusNotFound
 }

--- a/pkg/connector/team.go
+++ b/pkg/connector/team.go
@@ -102,8 +102,11 @@ func (o *teamResourceType) List(ctx context.Context, parentID *v2.ResourceId, pt
 	}
 
 	for _, team := range teams {
-		fullTeam, _, err := o.client.Teams.GetTeamByID(ctx, orgID, team.GetID())
+		fullTeam, resp, err := o.client.Teams.GetTeamByID(ctx, orgID, team.GetID())
 		if err != nil {
+			if isNotFoundError(resp) {
+				continue
+			}
 			return nil, "", nil, err
 		}
 
@@ -178,6 +181,9 @@ func (o *teamResourceType) Grants(ctx context.Context, resource *v2.Resource, pT
 
 	users, resp, err := o.client.Teams.ListTeamMembersByID(ctx, org.GetID(), githubID, &opts)
 	if err != nil {
+		if isNotFoundError(resp) {
+			return nil, "", nil, nil
+		}
 		return nil, "", nil, fmt.Errorf("github-connectorv2: failed to fetch team members: %w", err)
 	}
 
@@ -195,6 +201,9 @@ func (o *teamResourceType) Grants(ctx context.Context, resource *v2.Resource, pT
 	for _, user := range users {
 		membership, _, err := o.client.Teams.GetTeamMembershipByID(ctx, org.GetID(), githubID, user.GetLogin())
 		if err != nil {
+			if isNotFoundError(resp) {
+				continue
+			}
 			return nil, "", nil, fmt.Errorf("github-connectorv2: failed to get team membership for user: %w", err)
 		}
 

--- a/pkg/connector/team.go
+++ b/pkg/connector/team.go
@@ -12,9 +12,11 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	rType "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"github.com/google/go-github/v63/github"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
 )
 
 const (
@@ -105,7 +107,7 @@ func (o *teamResourceType) List(ctx context.Context, parentID *v2.ResourceId, pt
 		fullTeam, resp, err := o.client.Teams.GetTeamByID(ctx, orgID, team.GetID())
 		if err != nil {
 			if isNotFoundError(resp) {
-				continue
+				return nil, "", nil, uhttp.WrapErrors(codes.NotFound, fmt.Sprintf("team: %d not found", team.GetID()))
 			}
 			return nil, "", nil, err
 		}
@@ -182,7 +184,7 @@ func (o *teamResourceType) Grants(ctx context.Context, resource *v2.Resource, pT
 	users, resp, err := o.client.Teams.ListTeamMembersByID(ctx, org.GetID(), githubID, &opts)
 	if err != nil {
 		if isNotFoundError(resp) {
-			return nil, "", nil, nil
+			return nil, "", nil, uhttp.WrapErrors(codes.NotFound, fmt.Sprintf("org: %d not found", org.GetID()))
 		}
 		return nil, "", nil, fmt.Errorf("github-connectorv2: failed to fetch team members: %w", err)
 	}
@@ -202,7 +204,7 @@ func (o *teamResourceType) Grants(ctx context.Context, resource *v2.Resource, pT
 		membership, _, err := o.client.Teams.GetTeamMembershipByID(ctx, org.GetID(), githubID, user.GetLogin())
 		if err != nil {
 			if isNotFoundError(resp) {
-				continue
+				return nil, "", nil, uhttp.WrapErrors(codes.NotFound, fmt.Sprintf("user: %s not found", user.GetLogin()))
 			}
 			return nil, "", nil, fmt.Errorf("github-connectorv2: failed to get team membership for user: %w", err)
 		}


### PR DESCRIPTION
Similar to https://github.com/ductone/c1/pull/9026, 
workflow failed when the resources deleted during sync.
We fixed it by ignoring the `404 not found` error.

### Tests -- deleted the teams from github after sync starts. 
Before changes. 
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/950dd361-bd16-49b7-9790-bb363cd30c18" />
After changes.
<img width="1284" alt="image" src="https://github.com/user-attachments/assets/871ace3c-bc8c-4730-875f-d4dd4bcde9d9" />
