### PR TITLE
[BB-454]baton-github: add expandable annotations to team sync

### DIFF
--- a/pkg/connector/repository.go
+++ b/pkg/connector/repository.go
@@ -227,9 +227,18 @@ func (o *repositoryResourceType) Grants(
 					return nil, "", nil, err
 				}
 
-				rv = append(rv, grant.NewGrant(resource, permission, tr.Id, grant.WithAnnotation(&v2.V1Identifier{
-					Id: fmt.Sprintf("repo-grant:%s:%d:%s", resource.Id.Resource, team.GetID(), permission),
-				})))
+				rv = append(rv, grant.NewGrant(resource, permission, tr.Id, grant.WithAnnotation(
+					&v2.V1Identifier{
+						Id: fmt.Sprintf("repo-grant:%s:%d:%s", resource.Id.Resource, team.GetID(), permission),
+					},
+					&v2.GrantExpandable{
+						EntitlementIds: []string{
+							entitlement.NewEntitlementID(tr, teamRoleMaintainer),
+							entitlement.NewEntitlementID(tr, teamRoleMember),
+						},
+						Shallow: true,
+					},
+				)))
 			}
 		}
 	default:


### PR DESCRIPTION
Previously, we list **all** the users who have access to the repo. However, some users can access to the repo via team access.
Therefore, it's better to show if the users inherit from the team which has access to the repo.

<img width="1256" alt="image" src="https://github.com/user-attachments/assets/2fd10d9b-8b2e-436c-8c82-335998068f91" />
