### PR TITLE
baton-github: refresh app token once it expires

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -203,7 +203,6 @@ func New(ctx context.Context, ghc *cfg.Github, appKey string) (*GitHub, error) {
 	}
 
 	var (
-		client    *github.Client
 		appClient *github.Client
 		ts        = oauth2.StaticTokenSource(
 			&oauth2.Token{AccessToken: patToken},
@@ -247,7 +246,7 @@ func New(ctx context.Context, ghc *cfg.Github, appKey string) (*GitHub, error) {
 		)
 	}
 
-	client, err = newGitHubClient(ctx, ghc.InstanceUrl, ts)
+	client, err := newGitHubClient(ctx, ghc.InstanceUrl, ts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -176,7 +176,7 @@ func (gh *GitHub) validateAppCredentials(ctx context.Context) (annotations.Annot
 }
 
 // newGitHubClient returns a new GitHub API client authenticated with an access token via oauth2.
-func newGitHubClient(ctx context.Context, instanceURL string, accessToken string) (*github.Client, error) {
+func newGitHubClient(ctx context.Context, instanceURL string, ts oauth2.TokenSource) (*github.Client, error) {
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return nil, err
@@ -184,9 +184,6 @@ func newGitHubClient(ctx context.Context, instanceURL string, accessToken string
 
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
 
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: accessToken},
-	)
 	tc := oauth2.NewClient(ctx, ts)
 	gc := github.NewClient(tc)
 
@@ -205,13 +202,24 @@ func New(ctx context.Context, ghc *cfg.Github, appKey string) (*GitHub, error) {
 		return nil, err
 	}
 
-	var appClient *github.Client
+	var (
+		client    *github.Client
+		appClient *github.Client
+		ts        = oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: patToken},
+		)
+	)
 	if jwttoken != "" {
 		if len(ghc.Orgs) != 1 {
 			return nil, fmt.Errorf("github-connector: only one org should be specified")
 		}
 
-		appClient, err = newGitHubClient(ctx, ghc.InstanceUrl, jwttoken)
+		appClient, err = newGitHubClient(ctx,
+			ghc.InstanceUrl,
+			oauth2.StaticTokenSource(
+				&oauth2.Token{AccessToken: jwttoken},
+			),
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -224,14 +232,26 @@ func New(ctx context.Context, ghc *cfg.Github, appKey string) (*GitHub, error) {
 		if err != nil {
 			return nil, err
 		}
-		patToken = token
+
+		ts = oauth2.ReuseTokenSource(
+			&oauth2.Token{
+				AccessToken: token.GetToken(),
+				Expiry:      token.GetExpiresAt().Time,
+			},
+			&appTokenRefresher{
+				ctx:            ctx,
+				instanceURL:    ghc.InstanceUrl,
+				installationID: installation.GetID(),
+				jwttoken:       jwttoken,
+			},
+		)
 	}
 
-	client, err := newGitHubClient(ctx, ghc.InstanceUrl, patToken)
+	client, err = newGitHubClient(ctx, ghc.InstanceUrl, ts)
 	if err != nil {
 		return nil, err
 	}
-	graphqlClient, err := newGitHubGraphqlClient(ctx, ghc.InstanceUrl, patToken)
+	graphqlClient, err := newGitHubGraphqlClient(ctx, ghc.InstanceUrl, ts)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +268,7 @@ func New(ctx context.Context, ghc *cfg.Github, appKey string) (*GitHub, error) {
 	return gh, nil
 }
 
-func newGitHubGraphqlClient(ctx context.Context, instanceURL string, accessToken string) (*githubv4.Client, error) {
+func newGitHubGraphqlClient(ctx context.Context, instanceURL string, ts oauth2.TokenSource) (*githubv4.Client, error) {
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return nil, err
@@ -256,9 +276,6 @@ func newGitHubGraphqlClient(ctx context.Context, instanceURL string, accessToken
 
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
 
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: accessToken},
-	)
 	tc := oauth2.NewClient(ctx, ts)
 
 	instanceURL = strings.TrimSuffix(instanceURL, "/")
@@ -331,16 +348,44 @@ func findInstallation(ctx context.Context, c *github.Client, orgName string) (*g
 	return installation, resp, nil
 }
 
-func getInstallationToken(ctx context.Context, c *github.Client, id int64) (string, error) {
+func getInstallationToken(ctx context.Context, c *github.Client, id int64) (*github.InstallationToken, error) {
 	token, resp, err := c.Apps.CreateInstallationToken(ctx, id, &github.InstallationTokenOptions{})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	if resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("GitHub API error: %s", body)
+		return nil, fmt.Errorf("GitHub API error: %s", body)
 	}
 
-	return token.GetToken(), nil
+	return token, nil
+}
+
+type appTokenRefresher struct {
+	ctx            context.Context
+	jwttoken       string
+	instanceURL    string
+	installationID int64
+}
+
+func (r *appTokenRefresher) Token() (*oauth2.Token, error) {
+	appClient, err := newGitHubClient(r.ctx,
+		r.instanceURL,
+		oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: r.jwttoken},
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := getInstallationToken(r.ctx, appClient, r.installationID)
+	if err != nil {
+		return nil, err
+	}
+	return &oauth2.Token{
+		AccessToken: token.GetToken(),
+		Expiry:      token.GetExpiresAt().Time,
+	}, nil
 }


### PR DESCRIPTION
Installation token is valid for 1 hour. today there is no way besides restarting connector once it expires. 

In this fix,
I add `refresher` that refreshes the installation token.

Alternatives:
use https://github.com/octokit/go-sdk as [github official web] suggests. However, This go-sdk is **unstable** and it doesn't support refreshing the token. 

#### Test. 
hard code the access token with the expired token, like 
```
&oauth2.Token{
  AccessToken: "ghs_HZj1sDHMFFLCWwxBYFVkt0GPyuZKOe2KEQ6f",
  Expiry:      time.Now().Add(-time.Hour),
},
```

##### Result.
{"level":"info","ts":1748383866.770987,"caller":"grpclog/component.go:34","msg":"[core][Server #1]Server created","system":"grpc","grpc_log":true}
{"level":"info","ts":1748383866.7716632,"caller":"grpclog/component.go:34","msg":"[core][Server #1 ListenSocket #2]ListenSocket created","system":"grpc","grpc_log":true}
{"level":"info","ts":1748383866.7778502,"caller":"grpclog/component.go:34","msg":"[core]CPU time info is unavailable on non-linux environments.","system":"grpc","grpc_log":true}
{"level":"info","ts":1748383866.925617,"caller":"sync/syncer.go:619","msg":"Syncing resource types..."}
{"level":"info","ts":1748383866.92849,"caller":"sync/syncer.go:81","msg":"Synced resource types","count":5}
{"level":"info","ts":1748383866.928517,"caller":"sync/syncer.go:779","msg":"Syncing resources..."}
{"level":"info","ts":1748383866.929743,"caller":"sync/syncer.go:87","msg":"Synced resources","resource_type_id":"org_role","count":0}
{"level":"info","ts":1748383866.930481,"caller":"sync/syncer.go:87","msg":"Synced resources","resource_type_id":"repository","count":0}
{"level":"info","ts":1748383866.931062,"caller":"sync/syncer.go:87","msg":"Synced resources","resource_type_id":"user","count":0}
{"level":"info","ts":1748383866.931659,"caller":"sync/syncer.go:87","msg":"Synced resources","resource_type_id":"team","count":0}
**refresh token: ghs_bcj3tLoQs4Pmn7nf0DQbR5mWuQXG0h16FrfH**


###### Before the changes.
it doesn't work if we use the expired token. 
<img width="963" alt="image" src="https://github.com/user-attachments/assets/044ea1de-bbe9-4b1c-ad9d-9b12e6d24d13" />
