### PR TITLE
Remove field sorting in config

### DIFF
--- a/.github/workflows/output_config.yaml
+++ b/.github/workflows/output_config.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Run and save output
         # Sort the fields array by name to ensure consistent ordering
         run: |
-          ./connector config | jq '{ fields: (.fields | sort_by(.name)) }' > config_schema.json
+          ./connector config | jq > config_schema.json
 
       - name: Commit changes
         uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
This was a mistake on my part when we were trying to troubleshoot all of the bot commits for creating the config file. The sorting I added was wrong and didn't allow for anything other than fields to display in the config. 🤦 