### PR TITLE
Remove sorting from output config

### DIFF
--- a/.github/workflows/output_config.yaml
+++ b/.github/workflows/output_config.yaml
@@ -25,9 +25,7 @@ jobs:
         run: go build -o connector ./cmd/baton-github
 
       - name: Run and save output
-        # Sort the fields array by name to ensure consistent ordering
-        run: |
-          ./connector config | jq '.fields |= sort_by(.name)' > config_schema.json
+        run: ./connector config > config_schema.json
 
       - name: Commit changes
         uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
The sorting logic is moved to baton-sdk. https://github.com/ConductorOne/baton-sdk/pull/392