### PR TITLE
[BB-761] baton-github: skip PermissionDenied error

### DIFF
--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -220,3 +220,10 @@ func isNotFoundError(resp *github.Response) bool {
 	}
 	return resp.StatusCode == http.StatusNotFound
 }
+
+func isPermissionDeniedError(resp *github.Response) bool {
+	if resp == nil {
+		return false
+	}
+	return resp.StatusCode == http.StatusForbidden
+}

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -220,10 +220,3 @@ func isNotFoundError(resp *github.Response) bool {
 	}
 	return resp.StatusCode == http.StatusNotFound
 }
-
-func isPermissionDeniedError(resp *github.Response) bool {
-	if resp == nil {
-		return false
-	}
-	return resp.StatusCode == http.StatusForbidden
-}

--- a/pkg/connector/repository.go
+++ b/pkg/connector/repository.go
@@ -3,6 +3,7 @@ package connector
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -133,6 +134,7 @@ func (o *repositoryResourceType) Grants(
 	resource *v2.Resource,
 	pToken *pagination.Token,
 ) ([]*v2.Grant, string, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
 	bag, page, err := parsePageToken(pToken.Token, resource.Id)
 	if err != nil {
 		return nil, "", nil, err
@@ -163,6 +165,10 @@ func (o *repositoryResourceType) Grants(
 		}
 		users, resp, err := o.client.Repositories.ListCollaborators(ctx, orgName, resource.DisplayName, opts)
 		if err != nil {
+			if resp.StatusCode == http.StatusForbidden {
+				l.Warn("insufficient access to list collaborators", zap.String("repository", resource.DisplayName))
+				return nil, "", nil, nil
+			}
 			return nil, "", nil, fmt.Errorf("github-connector: failed to list repos: %w", err)
 		}
 
@@ -202,6 +208,10 @@ func (o *repositoryResourceType) Grants(
 		}
 		teams, resp, err := o.client.Repositories.ListTeams(ctx, orgName, resource.DisplayName, opts)
 		if err != nil {
+			if resp.StatusCode == http.StatusForbidden {
+				l.Warn("insufficient access to list teams", zap.String("repository", resource.DisplayName))
+				return nil, "", nil, nil
+			}
 			return nil, "", nil, fmt.Errorf("github-connector: failed to list repos: %w", err)
 		}
 

--- a/pkg/connector/repository.go
+++ b/pkg/connector/repository.go
@@ -167,7 +167,11 @@ func (o *repositoryResourceType) Grants(
 		if err != nil {
 			if resp.StatusCode == http.StatusForbidden {
 				l.Warn("insufficient access to list collaborators", zap.String("repository", resource.DisplayName))
-				return nil, "", nil, nil
+				pageToken, err := skipGrantsForResourceType(bag)
+				if err != nil {
+					return nil, "", nil, err
+				}
+				return nil, pageToken, nil, nil
 			}
 			return nil, "", nil, fmt.Errorf("github-connector: failed to list repos: %w", err)
 		}
@@ -210,7 +214,11 @@ func (o *repositoryResourceType) Grants(
 		if err != nil {
 			if resp.StatusCode == http.StatusForbidden {
 				l.Warn("insufficient access to list teams", zap.String("repository", resource.DisplayName))
-				return nil, "", nil, nil
+				pageToken, err := skipGrantsForResourceType(bag)
+				if err != nil {
+					return nil, "", nil, err
+				}
+				return nil, pageToken, nil, nil
 			}
 			return nil, "", nil, fmt.Errorf("github-connector: failed to list repos: %w", err)
 		}
@@ -393,4 +401,16 @@ func repositoryBuilder(client *github.Client, orgCache *orgNameCache) *repositor
 		client:       client,
 		orgCache:     orgCache,
 	}
+}
+
+func skipGrantsForResourceType(bag *pagination.Bag) (string, error) {
+	err := bag.Next("")
+	if err != nil {
+		return "", err
+	}
+	pageToken, err := bag.Marshal()
+	if err != nil {
+		return "", err
+	}
+	return pageToken, nil
 }


### PR DESCRIPTION
ref [githubv2 doc](https://www.conductorone.com/docs/baton/github-v2/)
<img width="815" alt="image" src="https://github.com/user-attachments/assets/2208b2f0-e43f-46e2-9c79-8dcc37b7c160" />

We need to skip the `PermissionDenied` error during sync. 
There are some places where `Forbidden` error is ignored. See [here](https://github.com/search?q=repo%3AConductorOne%2Fbaton-github+%22http.StatusForbidden%22&type=code)

However,  @btipling says it's a scary feature, since it would churn data if the permission get deleted accidentally when it's shouldn't be.

We could discuss more on that. 


#### Test. 
Before changes.
```
c.method":"ListGrants","peer.address":"127.0.0.1:62857","error":"error: listing grants for resource repository/993471239 failed: github-connector: failed to list repos: GET https://api.github.com/repos/laurenTestC1Org/test-BB761-private/teams: 403 Resource not accessible by personal access token []","grpc.code":"Unknown","grpc.time_ms":141.894}
{"level":"error","ts":1748646013.277557,"caller":"ratelimit/grpc.go:134","msg":"ratelimit: error running client request","error":"rpc error: code = Unknown desc = error: listing grants for resource repository/993471239 failed: github-connector: failed to list repos: GET https://api.github.com/repos/laurenTestC1Org/test-BB761-private/teams: 403 Resource not accessible by personal access token []"}
{"level":"error","ts":1748646013.285064,"caller":"connectorrunner/runner.go:204","msg":"runner: error processing on-demand task","error":"runner: error processing task: rpc error: code = Unknown desc = error: listing grants for resource repository/993471239 failed: github-connector: failed to list repos: GET https://api.github.com/repos/laurenTestC1Org/test-BB761-private/teams: 403 Resource not accessible by personal access token []","task_id":"","task_type":"sync_full"}
{"level":"error","ts":1748646013.285162,"caller":"cli/commands.go:291","msg":"error running connector","error":"runner: error processing task: rpc error: code = Unknown desc = error: listing grants for resource repository/993471239 failed: github-connector: failed to list repos: GET https://api.github.com/repos/laurenTestC1Org/test-BB761-private/teams: 403 Resource not accessible by personal access token []"}
runner: error processing task: rpc error: code = Unknown desc = error: listing grants for resource repository/993471239 failed: github-connector: failed to list repos: GET https://api.github.com/repos/laurenTestC1Org/test-BB761-private/teams: 403 Resource not accessible by personal access token []
```
After changes.
<img width="1431" alt="image" src="https://github.com/user-attachments/assets/4898b737-912a-4c37-a0bf-b2fd6b82b938" />
