### PR TITLE
add --sync-secrets to generate capabilities

### DIFF
--- a/.github/workflows/output_capabilities.yaml
+++ b/.github/workflows/output_capabilities.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Run and save output
         env:
           BATON_TOKEN: test
-        run: ./connector capabilities > baton_capabilities.json
+        run: ./connector --sync-secrets capabilities > baton_capabilities.json
 
       - name: Commit changes
         uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
`api-key` is missing from `capabilites.json`. 

#### Test
{
  "@type": "type.googleapis.com/c1.connector.v2.ConnectorCapabilities",
  "resourceTypeCapabilities": [
    {
      "resourceType": {
        "id": "api-key",
        "displayName": "API Key",
        "traits": [
          "TRAIT_SECRET"
        ],
        "annotations": [
          {
            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
          }
        ]
      },
      "capabilities": [
        "CAPABILITY_SYNC"
      ]
    },