### PR TITLE
[BB-981] baton-github: ignore 404 error when syncing invitations

### DIFF
--- a/pkg/connector/invitation.go
+++ b/pkg/connector/invitation.go
@@ -10,7 +10,9 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"github.com/google/go-github/v69/github"
+	"google.golang.org/grpc/codes"
 )
 
 func invitationToUserResource(invitation *github.Invitation) (*v2.Resource, error) {
@@ -69,6 +71,9 @@ func (i *invitationResourceType) List(ctx context.Context, parentID *v2.Resource
 		PerPage: pt.Size,
 	})
 	if err != nil {
+		if isNotFoundError(resp) {
+			return nil, "", nil, uhttp.WrapErrors(codes.NotFound, fmt.Sprintf("org: %d not found", orgName))
+		}
 		return nil, "", nil, fmt.Errorf("github-connector: ListPendingOrgInvitatioins failed: %w", err)
 	}
 


### PR DESCRIPTION
We got this 404 error when we sync invitations. 
I don't know what's going on, but let's ignore this 404 for now. 

I will investigate what's going one here. 