### PR TITLE
[BB-1027] baton-github: use max_page_size to limit the api usage.

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -31,7 +31,7 @@ const githubDotCom = "https://github.com"
 
 var (
 	ValidAssetDomains     = []string{"avatars.githubusercontent.com"}
-	max_page_size     int = 100
+	max_page_size     int = 100 // maximum page size github supported.
 )
 
 var (
@@ -427,7 +427,7 @@ func getOrgs(ctx context.Context, client *github.Client, orgs []string) ([]strin
 		orgLogins []string
 	)
 	for {
-		orgs, resp, err := client.Organizations.List(ctx, "", &github.ListOptions{Page: page})
+		orgs, resp, err := client.Organizations.List(ctx, "", &github.ListOptions{Page: page, PerPage: max_page_size})
 		if err != nil {
 			return nil, fmt.Errorf("github-connector: failed to retrieve org: %w", err)
 		}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -29,7 +29,10 @@ import (
 
 const githubDotCom = "https://github.com"
 
-var ValidAssetDomains = []string{"avatars.githubusercontent.com"}
+var (
+	ValidAssetDomains     = []string{"avatars.githubusercontent.com"}
+	max_page_size     int = 100
+)
 
 var (
 	resourceTypeOrg = &v2.ResourceType{

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -31,7 +31,7 @@ const githubDotCom = "https://github.com"
 
 var (
 	ValidAssetDomains     = []string{"avatars.githubusercontent.com"}
-	max_page_size     int = 100 // maximum page size github supported.
+	maxPageSize       int = 100 // maximum page size github supported.
 )
 
 var (
@@ -427,7 +427,7 @@ func getOrgs(ctx context.Context, client *github.Client, orgs []string) ([]strin
 		orgLogins []string
 	)
 	for {
-		orgs, resp, err := client.Organizations.List(ctx, "", &github.ListOptions{Page: page, PerPage: max_page_size})
+		orgs, resp, err := client.Organizations.List(ctx, "", &github.ListOptions{Page: page, PerPage: maxPageSize})
 		if err != nil {
 			return nil, fmt.Errorf("github-connector: failed to retrieve org: %w", err)
 		}

--- a/pkg/connector/org.go
+++ b/pkg/connector/org.go
@@ -95,7 +95,7 @@ func (o *orgResourceType) List(
 
 	opts := &github.ListOptions{
 		Page:    page,
-		PerPage: pToken.Size,
+		PerPage: max_page_size,
 	}
 
 	orgs, resp, err := o.client.Organizations.List(ctx, "", opts)
@@ -188,7 +188,7 @@ func (o *orgResourceType) Grants(
 	opts := github.ListMembersOptions{
 		ListOptions: github.ListOptions{
 			Page:    page,
-			PerPage: pToken.Size,
+			PerPage: max_page_size,
 		},
 	}
 

--- a/pkg/connector/org.go
+++ b/pkg/connector/org.go
@@ -95,7 +95,7 @@ func (o *orgResourceType) List(
 
 	opts := &github.ListOptions{
 		Page:    page,
-		PerPage: max_page_size,
+		PerPage: maxPageSize,
 	}
 
 	orgs, resp, err := o.client.Organizations.List(ctx, "", opts)
@@ -188,7 +188,7 @@ func (o *orgResourceType) Grants(
 	opts := github.ListMembersOptions{
 		ListOptions: github.ListOptions{
 			Page:    page,
-			PerPage: max_page_size,
+			PerPage: maxPageSize,
 		},
 	}
 

--- a/pkg/connector/org_role.go
+++ b/pkg/connector/org_role.go
@@ -163,7 +163,8 @@ func (o *orgRoleResourceType) Grants(
 		})
 	case resourceTypeUser.Id:
 		opts := &github.ListOptions{
-			Page: page,
+			Page:    page,
+			PerPage: max_page_size,
 		}
 		users, resp, err := o.client.Organizations.ListUsersAssignedToOrgRole(ctx, orgName, roleID, opts)
 		if err != nil {

--- a/pkg/connector/org_role.go
+++ b/pkg/connector/org_role.go
@@ -164,7 +164,7 @@ func (o *orgRoleResourceType) Grants(
 	case resourceTypeUser.Id:
 		opts := &github.ListOptions{
 			Page:    page,
-			PerPage: max_page_size,
+			PerPage: maxPageSize,
 		}
 		users, resp, err := o.client.Organizations.ListUsersAssignedToOrgRole(ctx, orgName, roleID, opts)
 		if err != nil {
@@ -209,7 +209,7 @@ func (o *orgRoleResourceType) Grants(
 	case resourceTypeTeam.Id:
 		opts := &github.ListOptions{
 			Page:    page,
-			PerPage: max_page_size,
+			PerPage: maxPageSize,
 		}
 		teams, resp, err := o.client.Organizations.ListTeamsAssignedToOrgRole(ctx, orgName, roleID, opts)
 		if err != nil {

--- a/pkg/connector/org_role.go
+++ b/pkg/connector/org_role.go
@@ -208,7 +208,8 @@ func (o *orgRoleResourceType) Grants(
 		}
 	case resourceTypeTeam.Id:
 		opts := &github.ListOptions{
-			Page: page,
+			Page:    page,
+			PerPage: max_page_size,
 		}
 		teams, resp, err := o.client.Organizations.ListTeamsAssignedToOrgRole(ctx, orgName, roleID, opts)
 		if err != nil {

--- a/pkg/connector/repository.go
+++ b/pkg/connector/repository.go
@@ -82,7 +82,7 @@ func (o *repositoryResourceType) List(ctx context.Context, parentID *v2.Resource
 	opts := &github.RepositoryListByOrgOptions{
 		ListOptions: github.ListOptions{
 			Page:    page,
-			PerPage: max_page_size,
+			PerPage: maxPageSize,
 		},
 	}
 
@@ -163,7 +163,7 @@ func (o *repositoryResourceType) Grants(
 			Affiliation: "all",
 			ListOptions: github.ListOptions{
 				Page:    page,
-				PerPage: max_page_size,
+				PerPage: maxPageSize,
 			},
 		}
 		users, resp, err := o.client.Repositories.ListCollaborators(ctx, orgName, resource.DisplayName, opts)
@@ -212,7 +212,7 @@ func (o *repositoryResourceType) Grants(
 	case resourceTypeTeam.Id:
 		opts := &github.ListOptions{
 			Page:    page,
-			PerPage: max_page_size,
+			PerPage: maxPageSize,
 		}
 		teams, resp, err := o.client.Repositories.ListTeams(ctx, orgName, resource.DisplayName, opts)
 		if err != nil {

--- a/pkg/connector/repository.go
+++ b/pkg/connector/repository.go
@@ -211,7 +211,8 @@ func (o *repositoryResourceType) Grants(
 
 	case resourceTypeTeam.Id:
 		opts := &github.ListOptions{
-			Page: page,
+			Page:    page,
+			PerPage: max_page_size,
 		}
 		teams, resp, err := o.client.Repositories.ListTeams(ctx, orgName, resource.DisplayName, opts)
 		if err != nil {

--- a/pkg/connector/repository.go
+++ b/pkg/connector/repository.go
@@ -82,7 +82,7 @@ func (o *repositoryResourceType) List(ctx context.Context, parentID *v2.Resource
 	opts := &github.RepositoryListByOrgOptions{
 		ListOptions: github.ListOptions{
 			Page:    page,
-			PerPage: pt.Size,
+			PerPage: max_page_size,
 		},
 	}
 
@@ -161,7 +161,10 @@ func (o *repositoryResourceType) Grants(
 	case resourceTypeUser.Id:
 		opts := &github.ListCollaboratorsOptions{
 			Affiliation: "all",
-			ListOptions: github.ListOptions{Page: page},
+			ListOptions: github.ListOptions{
+				Page:    page,
+				PerPage: max_page_size,
+			},
 		}
 		users, resp, err := o.client.Repositories.ListCollaborators(ctx, orgName, resource.DisplayName, opts)
 		if err != nil {

--- a/pkg/connector/team.go
+++ b/pkg/connector/team.go
@@ -78,7 +78,7 @@ func (o *teamResourceType) List(ctx context.Context, parentID *v2.ResourceId, pt
 
 	opts := &github.ListOptions{
 		Page:    page,
-		PerPage: pt.Size,
+		PerPage: max_page_size,
 	}
 
 	orgID, err := parseResourceToGitHub(parentID)
@@ -175,7 +175,10 @@ func (o *teamResourceType) Grants(ctx context.Context, resource *v2.Resource, pT
 	}
 
 	opts := github.TeamListTeamMembersOptions{
-		ListOptions: github.ListOptions{Page: page},
+		ListOptions: github.ListOptions{
+			Page:    page,
+			PerPage: max_page_size,
+		},
 	}
 
 	users, resp, err := o.client.Teams.ListTeamMembersByID(ctx, org.GetID(), githubID, &opts)

--- a/pkg/connector/team.go
+++ b/pkg/connector/team.go
@@ -78,7 +78,7 @@ func (o *teamResourceType) List(ctx context.Context, parentID *v2.ResourceId, pt
 
 	opts := &github.ListOptions{
 		Page:    page,
-		PerPage: max_page_size,
+		PerPage: maxPageSize,
 	}
 
 	orgID, err := parseResourceToGitHub(parentID)
@@ -177,7 +177,7 @@ func (o *teamResourceType) Grants(ctx context.Context, resource *v2.Resource, pT
 	opts := github.TeamListTeamMembersOptions{
 		ListOptions: github.ListOptions{
 			Page:    page,
-			PerPage: max_page_size,
+			PerPage: maxPageSize,
 		},
 	}
 

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -123,7 +123,10 @@ func (o *userResourceType) List(ctx context.Context, parentID *v2.ResourceId, pt
 	var restApiRateLimit *v2.RateLimitDescription
 
 	opts := github.ListMembersOptions{
-		ListOptions: github.ListOptions{Page: page, PerPage: pt.Size},
+		ListOptions: github.ListOptions{
+			Page:    page,
+			PerPage: max_page_size,
+		},
 	}
 
 	users, resp, err := o.client.Organizations.ListMembers(ctx, orgName, &opts)

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -125,7 +125,7 @@ func (o *userResourceType) List(ctx context.Context, parentID *v2.ResourceId, pt
 	opts := github.ListMembersOptions{
 		ListOptions: github.ListOptions{
 			Page:    page,
-			PerPage: max_page_size,
+			PerPage: maxPageSize,
 		},
 	}
 


### PR DESCRIPTION
<img width="547" alt="image" src="https://github.com/user-attachments/assets/93873a91-8138-4f0b-8d4a-1a1762426684" />
  
github returns a maximum of 100 items per api. 

Today, We met the issue where the sync takes so long and hits the rate limit.
We should use max_page_size to limit the api usage.