### PR TITLE
updated org.go to use "owner" as entitlement slug at the org level instead of "admin" 

### DIFF
--- a/pkg/connector/org.go
+++ b/pkg/connector/org.go
@@ -22,7 +22,7 @@ import (
 const (
 	orgRoleMember       = "member"
 	orgRoleDirectMember = "direct_member" // invite
-	orgRoleAdmin        = "admin"
+	orgRoleAdmin        = "owner"
 )
 
 var orgAccessLevels = []string{
@@ -159,7 +159,7 @@ func (o *orgResourceType) Entitlements(
 	))
 	rv = append(rv, entitlement.NewPermissionEntitlement(resource, orgRoleAdmin,
 		entitlement.WithDisplayName(fmt.Sprintf("%s Org %s", resource.DisplayName, titleCase(orgRoleAdmin))),
-		entitlement.WithDescription(fmt.Sprintf("Access to %s org in GitHub", resource.DisplayName)),
+		entitlement.WithDescription(fmt.Sprintf("Owner of %s org in GitHub", resource.DisplayName)),
 		entitlement.WithAnnotation(&v2.V1Identifier{
 			Id: fmt.Sprintf("org:%s:role:%s", resource.Id.Resource, orgRoleAdmin),
 		}),


### PR DESCRIPTION
Customer noted that organization owner entitlements appear as "admin" in the C1 app, where in GitHub this organization level entitlement appears as "Owner". For the sake of consistency, and at the request of audit, they requested that the organization owner entitlement appears as "owner" in the C1 app. This PR simply changes the `orgRoleAdmin` constant in org.go from "admin" to "owner".