### PR TITLE
fix: handle Enterprise SAML configuration gracefully

### DIFF
--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -175,9 +175,21 @@ func (o *userResourceType) List(ctx context.Context, parentID *v2.ResourceId, pt
 			}
 			err = o.graphqlClient.Query(ctx, &q, variables)
 			if err != nil {
-				return nil, "", nil, err
+				// When SAML is configured at the Enterprise level (not org level),
+				// GitHub returns this error. Fall back to using the regular user email
+				// and disable further SAML queries for this connector instance.
+				if strings.Contains(err.Error(), "SAML identity provider is disabled when an Enterprise SAML identity provider is available") {
+					l.Debug("org SAML disabled in favor of Enterprise SAML, skipping SAML identity enrichment",
+						zap.String("org", orgName),
+						zap.String("user", u.GetLogin()))
+					samlDisabled := false
+					o.hasSAMLEnabled = &samlDisabled
+					hasSamlBool = false
+				} else {
+					return nil, "", nil, err
+				}
 			}
-			if len(q.Organization.SamlIdentityProvider.ExternalIdentities.Edges) == 1 {
+			if err == nil && len(q.Organization.SamlIdentityProvider.ExternalIdentities.Edges) == 1 {
 				samlIdent := q.Organization.SamlIdentityProvider.ExternalIdentities.Edges[0].Node.SamlIdentity
 				userEmail = samlIdent.NameId
 				setUserEmail := false


### PR DESCRIPTION
## Summary

- Fixes sync failure when an organization is part of a GitHub Enterprise with SAML configured at the Enterprise level (not the org level)
- Catches the specific error "The Organization's SAML identity provider is disabled when an Enterprise SAML identity provider is available" and falls back to using regular user email
- Disables further SAML queries after detecting Enterprise SAML to avoid redundant failing API calls

Fixes CXH-918

## Test plan

- [ ] Deploy to a test environment with an org that has Enterprise-level SAML configured
- [ ] Verify sync completes successfully without the SAML error
- [ ] Verify users are synced with their regular email addresses (SAML identity enrichment is skipped gracefully)
- [ ] Verify orgs with org-level SAML still work as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SAML authentication resilience for enterprise configurations. The system now handles specific enterprise SAML errors gracefully, allowing continued operation while preserving user identification through fallback mechanisms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->