### PR TITLE
[CXP-372] Add diagnostic logging for GitHub API errors

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -446,11 +446,6 @@ func getJWTToken(appID string, privateKey string) (string, error) {
 func findInstallation(ctx context.Context, c *github.Client, orgName string) (*github.Installation, error) {
 	installation, resp, err := c.Apps.FindOrganizationInstallation(ctx, orgName)
 	if err != nil {
-		l := ctxzap.Extract(ctx)
-		l.Warn("failed to find GitHub App installation",
-			zap.String("org", orgName),
-			zap.String("github_error", gitHubErrorMessage(err)),
-		)
 		return nil, wrapGitHubError(err, resp, fmt.Sprintf("github-connector: failed to find installation for org %s", orgName))
 	}
 	return installation, nil

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-github/v69/github"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/shurcooL/githubv4"
+	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -445,20 +446,35 @@ func getJWTToken(appID string, privateKey string) (string, error) {
 func findInstallation(ctx context.Context, c *github.Client, orgName string) (*github.Installation, error) {
 	installation, resp, err := c.Apps.FindOrganizationInstallation(ctx, orgName)
 	if err != nil {
-		return nil, wrapGitHubError(err, resp, "github-connector: failed to find installation")
+		l := ctxzap.Extract(ctx)
+		l.Warn("failed to find GitHub App installation",
+			zap.String("org", orgName),
+			zap.String("github_error", gitHubErrorMessage(err)),
+		)
+		return nil, wrapGitHubError(err, resp, fmt.Sprintf("github-connector: failed to find installation for org %s", orgName))
 	}
 	return installation, nil
 }
 
 func getInstallationToken(ctx context.Context, c *github.Client, id int64) (*github.InstallationToken, error) {
+	l := ctxzap.Extract(ctx)
 	token, resp, err := c.Apps.CreateInstallationToken(ctx, id, &github.InstallationTokenOptions{})
 	if err != nil {
-		return nil, err
+		l.Warn("failed to create GitHub App installation token",
+			zap.Int64("installation_id", id),
+			zap.String("github_error", gitHubErrorMessage(err)),
+		)
+		return nil, fmt.Errorf("github-connector: failed to create installation token for installation %d: %w", id, err)
 	}
 
 	if resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("GitHub API error: %s", body)
+		l.Warn("unexpected status creating GitHub App installation token",
+			zap.Int64("installation_id", id),
+			zap.Int("http_status", resp.StatusCode),
+			zap.String("response_body", string(body)),
+		)
+		return nil, fmt.Errorf("github-connector: unexpected status %d creating installation token for installation %d: %s", resp.StatusCode, id, body)
 	}
 
 	return token, nil

--- a/pkg/connector/enterprise_role.go
+++ b/pkg/connector/enterprise_role.go
@@ -13,8 +13,6 @@ import (
 	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"github.com/google/go-github/v69/github"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 )
 
@@ -60,13 +58,6 @@ func (o *enterpriseRoleResourceType) fillCache(ctx context.Context) error {
 		for continuePagination {
 			consumedLicenses, _, err := o.customClient.ListEnterpriseConsumedLicenses(ctx, enterprise, page)
 			if err != nil {
-				l := ctxzap.Extract(ctx)
-				l.Warn("failed to list enterprise consumed licenses",
-					zap.String("enterprise", enterprise),
-					zap.Int("page", page),
-					zap.String("endpoint", fmt.Sprintf("GET /enterprises/%s/consumed-licenses", enterprise)),
-					zap.Error(err),
-				)
 				return uhttp.WrapErrors(codes.PermissionDenied, fmt.Sprintf("baton-github: error listing enterprise consumed licenses for %s", enterprise), err)
 			}
 

--- a/pkg/connector/enterprise_role.go
+++ b/pkg/connector/enterprise_role.go
@@ -13,6 +13,8 @@ import (
 	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"github.com/google/go-github/v69/github"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 )
 
@@ -58,6 +60,13 @@ func (o *enterpriseRoleResourceType) fillCache(ctx context.Context) error {
 		for continuePagination {
 			consumedLicenses, _, err := o.customClient.ListEnterpriseConsumedLicenses(ctx, enterprise, page)
 			if err != nil {
+				l := ctxzap.Extract(ctx)
+				l.Warn("failed to list enterprise consumed licenses",
+					zap.String("enterprise", enterprise),
+					zap.Int("page", page),
+					zap.String("endpoint", fmt.Sprintf("GET /enterprises/%s/consumed-licenses", enterprise)),
+					zap.Error(err),
+				)
 				return uhttp.WrapErrors(codes.PermissionDenied, fmt.Sprintf("baton-github: error listing enterprise consumed licenses for %s", enterprise), err)
 			}
 

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -303,6 +303,32 @@ func isTemporarilyUnavailable(resp *github.Response) bool {
 		resp.StatusCode == http.StatusGatewayTimeout
 }
 
+// gitHubErrorMessage extracts a human-readable error message from a GitHub API error.
+// For *github.ErrorResponse, it includes the HTTP method, URL path, message, and sub-error details.
+// For other error types, it returns err.Error().
+func gitHubErrorMessage(err error) string {
+	var ghErr *github.ErrorResponse
+	if errors.As(err, &ghErr) {
+		msg := ghErr.Message
+		if ghErr.Response != nil && ghErr.Response.Request != nil {
+			msg = fmt.Sprintf("%s %s: %s", ghErr.Response.Request.Method, ghErr.Response.Request.URL.Path, msg)
+		}
+		if len(ghErr.Errors) > 0 {
+			var errDetails []string
+			for _, e := range ghErr.Errors {
+				detail := e.Message
+				if detail == "" {
+					detail = fmt.Sprintf("resource=%s field=%s code=%s", e.Resource, e.Field, e.Code)
+				}
+				errDetails = append(errDetails, detail)
+			}
+			msg = fmt.Sprintf("%s [%s]", msg, strings.Join(errDetails, "; "))
+		}
+		return msg
+	}
+	return err.Error()
+}
+
 // wrapGitHubError wraps GitHub API errors with appropriate gRPC status codes based on the HTTP response.
 // It handles rate limiting, authentication errors, permission errors, and generic errors.
 // The contextMsg parameter should describe the operation that failed (e.g., "failed to list teams").
@@ -337,10 +363,10 @@ func wrapGitHubError(err error, resp *github.Response, contextMsg string) error 
 	}
 
 	if isAuthError(resp) {
-		return uhttp.WrapErrors(codes.Unauthenticated, contextMsg, err)
+		return uhttp.WrapErrors(codes.Unauthenticated, fmt.Sprintf("%s: %s", contextMsg, gitHubErrorMessage(err)), err)
 	}
 	if isPermissionError(resp) {
-		return uhttp.WrapErrors(codes.PermissionDenied, contextMsg, err)
+		return uhttp.WrapErrors(codes.PermissionDenied, fmt.Sprintf("%s: %s", contextMsg, gitHubErrorMessage(err)), err)
 	}
 	return fmt.Errorf("%s: %w", contextMsg, err)
 }

--- a/pkg/connector/org.go
+++ b/pkg/connector/org.go
@@ -126,7 +126,10 @@ func (o *orgResourceType) List(
 		membership, resp, err := o.client.Organizations.GetOrgMembership(ctx, "", org.GetLogin())
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusForbidden {
-				l.Warn("insufficient access to list org membership, skipping org", zap.String("org", org.GetLogin()))
+				l.Warn("insufficient access to list org membership, skipping org",
+				zap.String("org", org.GetLogin()),
+				zap.String("github_error", gitHubErrorMessage(err)),
+			)
 				continue
 			}
 			return nil, nil, wrapGitHubError(err, resp, "github-connector: failed to get org membership")

--- a/pkg/connector/org.go
+++ b/pkg/connector/org.go
@@ -126,10 +126,10 @@ func (o *orgResourceType) List(
 		membership, resp, err := o.client.Organizations.GetOrgMembership(ctx, "", org.GetLogin())
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusForbidden {
-				l.Warn("insufficient access to list org membership, skipping org",
-				zap.String("org", org.GetLogin()),
-				zap.String("github_error", gitHubErrorMessage(err)),
-			)
+				l.Debug("insufficient access to list org membership, skipping org",
+					zap.String("org", org.GetLogin()),
+					zap.String("github_error", gitHubErrorMessage(err)),
+				)
 				continue
 			}
 			return nil, nil, wrapGitHubError(err, resp, "github-connector: failed to get org membership")

--- a/pkg/connector/org_role.go
+++ b/pkg/connector/org_role.go
@@ -85,7 +85,12 @@ func (o *orgRoleResourceType) List(
 	if err != nil {
 		// Handle permission errors gracefully
 		if resp != nil && (resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound) {
-			// Return empty list with no error to indicate we skipped this resource
+			l := ctxzap.Extract(ctx)
+			l.Warn("insufficient access to list organization roles, skipping",
+				zap.String("org", orgName),
+				zap.Int("http_status", resp.StatusCode),
+				zap.String("github_error", gitHubErrorMessage(err)),
+			)
 			return nil, &resourceSdk.SyncOpResults{}, nil
 		}
 		return nil, nil, wrapGitHubError(err, resp, "github-connector: failed to list organization roles")
@@ -169,6 +174,13 @@ func (o *orgRoleResourceType) Grants(
 		users, resp, err := o.client.Organizations.ListUsersAssignedToOrgRole(ctx, orgName, roleID, listOpts)
 		if err != nil {
 			if resp != nil && (resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound) {
+				l := ctxzap.Extract(ctx)
+				l.Warn("insufficient access to list users assigned to org role, skipping",
+					zap.String("org", orgName),
+					zap.Int64("role_id", roleID),
+					zap.Int("http_status", resp.StatusCode),
+					zap.String("github_error", gitHubErrorMessage(err)),
+				)
 				pageToken, err := bag.NextToken("")
 				if err != nil {
 					return nil, nil, err
@@ -215,7 +227,13 @@ func (o *orgRoleResourceType) Grants(
 		if err != nil {
 			// Handle permission errors without erroring out. Some customers may not want to give us permissions to get org roles and members.
 			if resp != nil && (resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound) {
-				// Return empty list with no error to indicate we skipped this resource
+				l := ctxzap.Extract(ctx)
+				l.Warn("insufficient access to list teams assigned to org role, skipping",
+					zap.String("org", orgName),
+					zap.Int64("role_id", roleID),
+					zap.Int("http_status", resp.StatusCode),
+					zap.String("github_error", gitHubErrorMessage(err)),
+				)
 				pageToken, err := bag.NextToken("")
 				if err != nil {
 					return nil, nil, err

--- a/pkg/connector/org_role.go
+++ b/pkg/connector/org_role.go
@@ -86,7 +86,7 @@ func (o *orgRoleResourceType) List(
 		// Handle permission errors gracefully
 		if resp != nil && (resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound) {
 			l := ctxzap.Extract(ctx)
-			l.Warn("insufficient access to list organization roles, skipping",
+			l.Debug("insufficient access to list organization roles, skipping",
 				zap.String("org", orgName),
 				zap.Int("http_status", resp.StatusCode),
 				zap.String("github_error", gitHubErrorMessage(err)),
@@ -175,7 +175,7 @@ func (o *orgRoleResourceType) Grants(
 		if err != nil {
 			if resp != nil && (resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound) {
 				l := ctxzap.Extract(ctx)
-				l.Warn("insufficient access to list users assigned to org role, skipping",
+				l.Debug("insufficient access to list users assigned to org role, skipping",
 					zap.String("org", orgName),
 					zap.Int64("role_id", roleID),
 					zap.Int("http_status", resp.StatusCode),
@@ -228,7 +228,7 @@ func (o *orgRoleResourceType) Grants(
 			// Handle permission errors without erroring out. Some customers may not want to give us permissions to get org roles and members.
 			if resp != nil && (resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound) {
 				l := ctxzap.Extract(ctx)
-				l.Warn("insufficient access to list teams assigned to org role, skipping",
+				l.Debug("insufficient access to list teams assigned to org role, skipping",
 					zap.String("org", orgName),
 					zap.Int64("role_id", roleID),
 					zap.Int("http_status", resp.StatusCode),

--- a/pkg/connector/repository.go
+++ b/pkg/connector/repository.go
@@ -178,7 +178,11 @@ func (o *repositoryResourceType) Grants(
 		users, resp, err := o.client.Repositories.ListCollaborators(ctx, orgName, resource.DisplayName, listOpts)
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusForbidden {
-				l.Warn("insufficient access to list collaborators", zap.String("repository", resource.DisplayName))
+				l.Warn("insufficient access to list collaborators, skipping",
+					zap.String("org", orgName),
+					zap.String("repository", resource.DisplayName),
+					zap.String("github_error", gitHubErrorMessage(err)),
+				)
 				pageToken, err := skipGrantsForResourceType(bag)
 				if err != nil {
 					return nil, nil, err
@@ -229,7 +233,11 @@ func (o *repositoryResourceType) Grants(
 		teams, resp, err := o.client.Repositories.ListTeams(ctx, orgName, resource.DisplayName, listOpts)
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusForbidden {
-				l.Warn("insufficient access to list teams", zap.String("repository", resource.DisplayName))
+				l.Warn("insufficient access to list teams for repository, skipping",
+					zap.String("org", orgName),
+					zap.String("repository", resource.DisplayName),
+					zap.String("github_error", gitHubErrorMessage(err)),
+				)
 				pageToken, err := skipGrantsForResourceType(bag)
 				if err != nil {
 					return nil, nil, err

--- a/pkg/connector/repository.go
+++ b/pkg/connector/repository.go
@@ -178,7 +178,7 @@ func (o *repositoryResourceType) Grants(
 		users, resp, err := o.client.Repositories.ListCollaborators(ctx, orgName, resource.DisplayName, listOpts)
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusForbidden {
-				l.Warn("insufficient access to list collaborators, skipping",
+				l.Debug("insufficient access to list collaborators, skipping",
 					zap.String("org", orgName),
 					zap.String("repository", resource.DisplayName),
 					zap.String("github_error", gitHubErrorMessage(err)),
@@ -233,7 +233,7 @@ func (o *repositoryResourceType) Grants(
 		teams, resp, err := o.client.Repositories.ListTeams(ctx, orgName, resource.DisplayName, listOpts)
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusForbidden {
-				l.Warn("insufficient access to list teams for repository, skipping",
+				l.Debug("insufficient access to list teams for repository, skipping",
 					zap.String("org", orgName),
 					zap.String("repository", resource.DisplayName),
 					zap.String("github_error", gitHubErrorMessage(err)),

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -198,7 +198,12 @@ func (o *userResourceType) List(ctx context.Context, parentID *v2.ResourceId, op
 						l.Warn("failed to load enterprise email cache", zap.Error(loadErr))
 					}
 				} else {
-					return nil, nil, err
+					l.Warn("GraphQL SAML identity query failed",
+						zap.String("org", orgName),
+						zap.String("user", u.GetLogin()),
+						zap.Error(err),
+					)
+					return nil, nil, fmt.Errorf("baton-github: GraphQL SAML identity query failed for user %s in org %s: %w", u.GetLogin(), orgName, err)
 				}
 			}
 			if err == nil && len(q.Organization.SamlIdentityProvider.ExternalIdentities.Edges) == 1 {
@@ -362,6 +367,12 @@ func (o *userResourceType) loadEnterpriseEmailCache(ctx context.Context, ss sess
 		for {
 			consumedLicenses, _, err := o.customClient.ListEnterpriseConsumedLicenses(ctx, enterprise, page)
 			if err != nil {
+				l.Warn("failed to fetch enterprise consumed licenses",
+					zap.String("enterprise", enterprise),
+					zap.Int("page", page),
+					zap.String("endpoint", fmt.Sprintf("GET /enterprises/%s/consumed-licenses", enterprise)),
+					zap.Error(err),
+				)
 				// Mark as loaded so we don't retry; partial data is still available.
 				_ = session.SetJSON(ctx, ss, enterpriseEmailCacheLoadedKey, true)
 				return fmt.Errorf("baton-github: failed to fetch enterprise consumed licenses for %s (page %d): %w", enterprise, page, err)
@@ -440,7 +451,11 @@ func (o *userResourceType) hasSAML(ctx context.Context, orgName string, ss sessi
 			}
 			return false, nil
 		}
-		return false, err
+		l.Warn("GraphQL SAML provider query failed",
+			zap.String("org", orgName),
+			zap.Error(err),
+		)
+		return false, fmt.Errorf("baton-github: GraphQL SAML provider query failed for org %s: %w", orgName, err)
 	}
 	if q.Organization.SamlIdentityProvider.Id != "" {
 		samlBool = true

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -198,11 +198,6 @@ func (o *userResourceType) List(ctx context.Context, parentID *v2.ResourceId, op
 						l.Warn("failed to load enterprise email cache", zap.Error(loadErr))
 					}
 				} else {
-					l.Debug("GraphQL SAML identity query failed",
-						zap.String("org", orgName),
-						zap.String("user", u.GetLogin()),
-						zap.Error(err),
-					)
 					return nil, nil, fmt.Errorf("baton-github: GraphQL SAML identity query failed for user %s in org %s: %w", u.GetLogin(), orgName, err)
 				}
 			}

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -198,7 +198,7 @@ func (o *userResourceType) List(ctx context.Context, parentID *v2.ResourceId, op
 						l.Warn("failed to load enterprise email cache", zap.Error(loadErr))
 					}
 				} else {
-					l.Warn("GraphQL SAML identity query failed",
+					l.Debug("GraphQL SAML identity query failed",
 						zap.String("org", orgName),
 						zap.String("user", u.GetLogin()),
 						zap.Error(err),


### PR DESCRIPTION
## Summary

When a customer's GitHub Enterprise sync fails with "Resource not accessible by integration", the logs don't identify which API call is failing. This makes it very difficult to troubleshoot permission issues for GitHub App setups with limited scopes.

This PR adds diagnostic logging so that every API error path surfaces the exact endpoint, HTTP status, and GitHub error message:

- **`gitHubErrorMessage()` helper** — extracts HTTP method, URL path, message, and sub-error details from `*github.ErrorResponse`
- **Enriched `wrapGitHubError()`** — auth/permission gRPC status messages now include the GitHub error details, so they propagate through the error chain to DD
- **Graceful-skip warn logs** — 403-skip paths in org, repository, and org_role syncers now log `github_error` so silently-skipped resources show the exact GitHub error
- **Enterprise consumed licenses API** — warn logging added to `enterprise_role.go` and `user.go` paths that bypass `wrapGitHubError()`
- **GraphQL SAML queries** — warn logging added to SAML identity and provider query error paths in `user.go`
- **GitHub App installation token** — warn logging added to `findInstallation` and `getInstallationToken` in `connector.go`

Supersedes #131

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (13 tests, 7 packages)
- [x] `make lint` passes (0 issues)
- [ ] Manual: configure a GitHub App with limited permissions and verify logs show which API endpoint failed

Fixes CXP-372