### PR TITLE
[CXP-372] Document Organization Administration permission for SAML/SSO

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Use "baton-github [command] --help" for more information about a command.
 To use this Baton connector, you need to create a GitHub organization access token with the following permissions:
 
 Org:
+- Administration: Read-only (required to detect SAML/SSO configuration)
 - Member Read and Write
 
 Repo:

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -192,6 +192,7 @@ In the **Permissions** section of the page, give the app the following permissio
 
     - Organization permissions:
 
+      - **Administration**: Read-only access (required to detect SAML/SSO configuration)
       - **Custom organization roles**: Read and write access
       - **Members**: Read and write access
   
@@ -439,7 +440,13 @@ Check that the connector data uploaded correctly. In ConductorOne, click **Apps*
 </Tab>
 </Tabs>
 
+## Troubleshooting
 
+### "Resource not accessible by integration" error
 
+If you see this error during sync, it most commonly means the GitHub App is missing the **Organization administration: Read-only** permission.
 
+This permission is required because the connector queries GitHub's GraphQL API to check whether your organization has SAML/SSO configured. GitHub restricts this data to apps with organization admin read access. Without it, the sync will fail.
+
+**To fix:** Go to your GitHub App settings, then navigate to **Permissions** > **Organization permissions** > **Administration** and set it to **Read-only**.
 


### PR DESCRIPTION
## Summary

- Add **Organization Administration: Read-only** to the documented GitHub App permissions
- Required to detect SAML/SSO configuration via the GraphQL `samlIdentityProvider` query
- Without it, the connector fails with "Resource not accessible by integration" during sync

Aligned with ConductorOne/docs#164.

Fixes CXP-372