### PR TITLE
fix: gracefully skip enterprise features when using GitHub App auth

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -234,8 +234,9 @@ func (gh *GitHub) validateAppCredentials(ctx context.Context) (annotations.Annot
 		l := ctxzap.Extract(ctx)
 		_, _, err := gh.customClient.ListEnterpriseConsumedLicenses(ctx, gh.enterprises[0], 1)
 		if err != nil {
-			l.Debug("enterprise consumed licenses API is not accessible — enterprise SAML email enrichment and enterprise role sync may fail at sync time"+
-				" (GitHub App installations cannot access this endpoint — use a PAT with enterprise admin scope)",
+			l.Debug("baton-github: enterprise features (--enterprises) require a Personal Access Token. "+
+				"GitHub App authentication cannot access the consumed-licenses API. "+
+				"Either switch to PAT auth or remove the --enterprises flag.",
 				zap.Error(err))
 		}
 	}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -125,7 +125,7 @@ func (gh *GitHub) ResourceSyncers(ctx context.Context) []connectorbuilder.Resour
 	}
 
 	if len(gh.enterprises) > 0 {
-		resourceSyncers = append(resourceSyncers, enterpriseRoleBuilder(gh.client, gh.customClient, gh.enterprises))
+		resourceSyncers = append(resourceSyncers, enterpriseRoleBuilder(gh.client, gh.appClient, gh.customClient, gh.enterprises))
 	}
 	return resourceSyncers
 }
@@ -212,7 +212,8 @@ func (gh *GitHub) Validate(ctx context.Context) (annotations.Annotations, error)
 		l := ctxzap.Extract(ctx)
 		_, _, err := gh.customClient.ListEnterpriseConsumedLicenses(ctx, gh.enterprises[0], 1)
 		if err != nil {
-			l.Debug("enterprise consumed licenses API is not accessible — enterprise SAML email enrichment and enterprise role sync may fail at sync time",
+			l.Debug("baton-github: enterprise features (--enterprises) require a Personal Access Token with enterprise admin scope. "+
+				"The consumed-licenses API is not accessible with the current token.",
 				zap.Error(err))
 		}
 	}

--- a/pkg/connector/enterprise_role.go
+++ b/pkg/connector/enterprise_role.go
@@ -22,6 +22,7 @@ import (
 type enterpriseRoleResourceType struct {
 	resourceType   *v2.ResourceType
 	client         *github.Client
+	appClient      *github.Client
 	customClient   *customclient.Client
 	enterprises    []string
 	roleUsersCache map[string][]string
@@ -64,7 +65,7 @@ func (o *enterpriseRoleResourceType) fillCache(ctx context.Context) error {
 		for continuePagination {
 			consumedLicenses, _, err := o.customClient.ListEnterpriseConsumedLicenses(ctx, enterprise, page)
 			if err != nil {
-				if page == 1 && isPermissionDenied(err) {
+				if page == 1 && o.appClient != nil && isPermissionDenied(err) {
 					l.Debug("baton-github: enterprise features (--enterprises) require a Personal Access Token. "+
 						"GitHub App authentication cannot access the consumed-licenses API. "+
 						"Either switch to PAT auth or remove the --enterprises flag.",
@@ -171,10 +172,11 @@ func (o *enterpriseRoleResourceType) Grants(
 	return ret, &resourceSdk.SyncOpResults{}, nil
 }
 
-func enterpriseRoleBuilder(client *github.Client, customClient *customclient.Client, enterprises []string) *enterpriseRoleResourceType {
+func enterpriseRoleBuilder(client *github.Client, appClient *github.Client, customClient *customclient.Client, enterprises []string) *enterpriseRoleResourceType {
 	return &enterpriseRoleResourceType{
 		resourceType:   resourceTypeEnterpriseRole,
 		client:         client,
+		appClient:      appClient,
 		customClient:   customClient,
 		enterprises:    enterprises,
 		roleUsersCache: make(map[string][]string),

--- a/pkg/connector/enterprise_role.go
+++ b/pkg/connector/enterprise_role.go
@@ -2,6 +2,7 @@ package connector
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -14,6 +15,8 @@ import (
 	"github.com/google/go-github/v69/github"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type enterpriseRoleResourceType struct {
@@ -61,12 +64,15 @@ func (o *enterpriseRoleResourceType) fillCache(ctx context.Context) error {
 		for continuePagination {
 			consumedLicenses, _, err := o.customClient.ListEnterpriseConsumedLicenses(ctx, enterprise, page)
 			if err != nil {
-				l.Debug("baton-github: enterprise features (--enterprises) require a Personal Access Token. "+
-					"GitHub App authentication cannot access the consumed-licenses API. "+
-					"Either switch to PAT auth or remove the --enterprises flag.",
-					zap.String("enterprise", enterprise),
-					zap.Error(err))
-				return nil
+				if page == 1 && isPermissionDenied(err) {
+					l.Debug("baton-github: enterprise features (--enterprises) require a Personal Access Token. "+
+						"GitHub App authentication cannot access the consumed-licenses API. "+
+						"Either switch to PAT auth or remove the --enterprises flag.",
+						zap.String("enterprise", enterprise),
+						zap.Error(err))
+					return nil
+				}
+				return fmt.Errorf("baton-github: error listing enterprise consumed licenses for %s: %w", enterprise, err)
 			}
 
 			if len(consumedLicenses.Users) == 0 {
@@ -174,4 +180,12 @@ func enterpriseRoleBuilder(client *github.Client, customClient *customclient.Cli
 		roleUsersCache: make(map[string][]string),
 		mu:             &sync.Mutex{},
 	}
+}
+
+func isPermissionDenied(err error) bool {
+	var grpcErr interface{ GRPCStatus() *status.Status }
+	if errors.As(err, &grpcErr) {
+		return grpcErr.GRPCStatus().Code() == codes.PermissionDenied
+	}
+	return false
 }

--- a/pkg/connector/enterprise_role.go
+++ b/pkg/connector/enterprise_role.go
@@ -12,6 +12,8 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/google/go-github/v69/github"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 )
 
 type enterpriseRoleResourceType struct {
@@ -50,6 +52,7 @@ func (o *enterpriseRoleResourceType) getRoleUsersCache(ctx context.Context) (map
 }
 
 func (o *enterpriseRoleResourceType) fillCache(ctx context.Context) error {
+	l := ctxzap.Extract(ctx)
 	for _, enterprise := range o.enterprises {
 		// GitHub's consumed-licenses API is 1-indexed; page 0 is undocumented
 		// and may return the same results as page 1, causing duplicates.
@@ -58,7 +61,12 @@ func (o *enterpriseRoleResourceType) fillCache(ctx context.Context) error {
 		for continuePagination {
 			consumedLicenses, _, err := o.customClient.ListEnterpriseConsumedLicenses(ctx, enterprise, page)
 			if err != nil {
-				return fmt.Errorf("baton-github: error listing enterprise consumed licenses for %s: %w", enterprise, err)
+				l.Debug("baton-github: enterprise features (--enterprises) require a Personal Access Token. "+
+					"GitHub App authentication cannot access the consumed-licenses API. "+
+					"Either switch to PAT auth or remove the --enterprises flag.",
+					zap.String("enterprise", enterprise),
+					zap.Error(err))
+				return nil
 			}
 
 			if len(consumedLicenses.Users) == 0 {


### PR DESCRIPTION
## Summary
- The consumed-licenses API (`/enterprises/{slug}/consumed-licenses`) is not accessible via GitHub App installation tokens — it requires a PAT with enterprise admin scope.
- Previously, using `--enterprises` with GitHub App auth caused the sync to fail hard when the enterprise role builder tried to call this API.
- Now `enterpriseRoleBuilder.fillCache()` logs a debug message and returns an empty cache (zero enterprise role resources) instead of aborting.
- Updated the `validateAppCredentials()` debug message to use consistent, actionable wording across all three callsites.

## What changed
- `pkg/connector/enterprise_role.go` — `fillCache()` catches the consumed-licenses error, logs a debug-level message, and returns `nil` (empty cache) so the sync continues.
- `pkg/connector/connector.go` — `validateAppCredentials()` debug log updated to match the same wording.

## Test plan
- [x] Built and ran `go test ./...` — all pass
- [x] Ran a full sync with GitHub App auth + `--enterprises mevans-test` + `--log-level debug` — sync completed successfully, debug messages appeared at validate time and at enterprise role list time, all other resource types synced normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)