### PR TITLE
Refactor to use StaticEntitlements for standard resource types

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -44,18 +44,18 @@ var (
 	resourceTypeOrg = &v2.ResourceType{
 		Id:          "org",
 		DisplayName: "Org",
-		Annotations: v1AnnotationsForResourceType("org"),
+		Annotations: skipEntitlementsAnnotations("org"),
 	}
 	resourceTypeTeam = &v2.ResourceType{
 		Id:          "team",
 		DisplayName: "Team",
 		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP},
-		Annotations: v1AnnotationsForResourceType("team"),
+		Annotations: skipEntitlementsAnnotations("team"),
 	}
 	resourceTypeRepository = &v2.ResourceType{
 		Id:          "repository",
 		DisplayName: "Repository",
-		Annotations: v1AnnotationsForResourceType("repository"),
+		Annotations: skipEntitlementsAnnotations("repository"),
 	}
 	resourceTypeUser = &v2.ResourceType{
 		Id:          "user",
@@ -83,13 +83,13 @@ var (
 		Id:          "org_role",
 		DisplayName: "Organization Role",
 		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_ROLE},
-		Annotations: v1AnnotationsForResourceType("org_role"),
+		Annotations: skipEntitlementsAnnotations("org_role"),
 	}
 	resourceTypeEnterpriseRole = &v2.ResourceType{
 		Id:          "enterprise_role",
 		DisplayName: "Enterprise Role",
 		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_ROLE},
-		Annotations: v1AnnotationsForResourceType("enterprise_role"),
+		Annotations: skipEntitlementsAnnotations("enterprise_role"),
 	}
 )
 

--- a/pkg/connector/enterprise_role.go
+++ b/pkg/connector/enterprise_role.go
@@ -127,13 +127,17 @@ func (o *enterpriseRoleResourceType) Entitlements(
 	resource *v2.Resource,
 	_ resourceSdk.SyncOpAttrs,
 ) ([]*v2.Entitlement, *resourceSdk.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+func (o *enterpriseRoleResourceType) StaticEntitlements(
+	_ context.Context,
+	_ resourceSdk.SyncOpAttrs,
+) ([]*v2.Entitlement, *resourceSdk.SyncOpResults, error) {
 	rv := []*v2.Entitlement{}
-	rv = append(rv, entitlement.NewAssignmentEntitlement(resource, "assigned",
-		entitlement.WithDisplayName(resource.DisplayName),
-		entitlement.WithDescription(fmt.Sprintf("Assignment to %s enterprise role in GitHub", resource.DisplayName)),
-		entitlement.WithAnnotation(&v2.V1Identifier{
-			Id: resource.Id.Resource,
-		}),
+	rv = append(rv, entitlement.NewAssignmentEntitlement(nil, "assigned",
+		entitlement.WithDisplayName("Role Assigned"),
+		entitlement.WithDescription("Assignment to enterprise role in GitHub"),
 		entitlement.WithGrantableTo(resourceTypeUser),
 	))
 

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -85,6 +85,13 @@ func v1AnnotationsForResourceType(resourceTypeID string) annotations.Annotations
 	return annos
 }
 
+func skipEntitlementsAnnotations(resourceTypeID string) annotations.Annotations {
+	annos := v1AnnotationsForResourceType(resourceTypeID)
+	annos.Update(&v2.SkipEntitlements{})
+
+	return annos
+}
+
 // parseResourceToGitHub returns the upstream API ID by looking at the last 'part' of the resource ID.
 func parseResourceToGitHub(id *v2.ResourceId) (int64, error) {
 	idParts := strings.Split(id.Resource, ":")

--- a/pkg/connector/org.go
+++ b/pkg/connector/org.go
@@ -159,21 +159,22 @@ func (o *orgResourceType) Entitlements(
 	resource *v2.Resource,
 	_ resourceSdk.SyncOpAttrs,
 ) ([]*v2.Entitlement, *resourceSdk.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+func (o *orgResourceType) StaticEntitlements(
+	_ context.Context,
+	_ resourceSdk.SyncOpAttrs,
+) ([]*v2.Entitlement, *resourceSdk.SyncOpResults, error) {
 	rv := make([]*v2.Entitlement, 0, len(orgAccessLevels))
-	rv = append(rv, entitlement.NewAssignmentEntitlement(resource, orgRoleMember,
-		entitlement.WithDisplayName(fmt.Sprintf("%s Org %s", resource.DisplayName, titleCase(orgRoleMember))),
-		entitlement.WithDescription(fmt.Sprintf("Access to %s org in GitHub", resource.DisplayName)),
-		entitlement.WithAnnotation(&v2.V1Identifier{
-			Id: fmt.Sprintf("org:%s:role:%s", resource.Id.Resource, orgRoleMember),
-		}),
+	rv = append(rv, entitlement.NewAssignmentEntitlement(nil, orgRoleMember,
+		entitlement.WithDisplayName("Org Member"),
+		entitlement.WithDescription("Access to org in GitHub as member"),
 		entitlement.WithGrantableTo(resourceTypeUser),
 	))
-	rv = append(rv, entitlement.NewPermissionEntitlement(resource, orgRoleAdmin,
-		entitlement.WithDisplayName(fmt.Sprintf("%s Org %s", resource.DisplayName, titleCase(orgRoleAdmin))),
-		entitlement.WithDescription(fmt.Sprintf("Access to %s org in GitHub", resource.DisplayName)),
-		entitlement.WithAnnotation(&v2.V1Identifier{
-			Id: fmt.Sprintf("org:%s:role:%s", resource.Id.Resource, orgRoleAdmin),
-		}),
+	rv = append(rv, entitlement.NewPermissionEntitlement(nil, orgRoleAdmin,
+		entitlement.WithDisplayName("Org Admin"),
+		entitlement.WithDescription("Access to org in GitHub as admin"),
 		entitlement.WithGrantableTo(resourceTypeUser),
 	))
 

--- a/pkg/connector/org_role.go
+++ b/pkg/connector/org_role.go
@@ -117,13 +117,17 @@ func (o *orgRoleResourceType) Entitlements(
 	resource *v2.Resource,
 	_ resourceSdk.SyncOpAttrs,
 ) ([]*v2.Entitlement, *resourceSdk.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+func (o *orgRoleResourceType) StaticEntitlements(
+	_ context.Context,
+	_ resourceSdk.SyncOpAttrs,
+) ([]*v2.Entitlement, *resourceSdk.SyncOpResults, error) {
 	rv := make([]*v2.Entitlement, 0, 1)
-	rv = append(rv, entitlement.NewAssignmentEntitlement(resource, "assigned",
-		entitlement.WithDisplayName(resource.DisplayName),
-		entitlement.WithDescription(fmt.Sprintf("Assignment to %s role in GitHub", resource.DisplayName)),
-		entitlement.WithAnnotation(&v2.V1Identifier{
-			Id: fmt.Sprintf("org_role:%s", resource.Id.Resource),
-		}),
+	rv = append(rv, entitlement.NewAssignmentEntitlement(nil, "assigned",
+		entitlement.WithDisplayName("Role Assigned"),
+		entitlement.WithDescription("Assignment to role in GitHub"),
 		entitlement.WithGrantableTo(resourceTypeUser),
 	))
 

--- a/pkg/connector/repository.go
+++ b/pkg/connector/repository.go
@@ -126,14 +126,15 @@ func (o *repositoryResourceType) List(ctx context.Context, parentID *v2.Resource
 }
 
 func (o *repositoryResourceType) Entitlements(_ context.Context, resource *v2.Resource, _ resourceSdk.SyncOpAttrs) ([]*v2.Entitlement, *resourceSdk.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+func (o *repositoryResourceType) StaticEntitlements(_ context.Context, _ resourceSdk.SyncOpAttrs) ([]*v2.Entitlement, *resourceSdk.SyncOpResults, error) {
 	rv := make([]*v2.Entitlement, 0, len(repoAccessLevels))
 	for _, level := range repoAccessLevels {
-		rv = append(rv, entitlement.NewPermissionEntitlement(resource, level,
-			entitlement.WithDisplayName(fmt.Sprintf("%s Repo %s", resource.DisplayName, titleCase(level))),
-			entitlement.WithDescription(fmt.Sprintf("Access to %s repository in GitHub", resource.DisplayName)),
-			entitlement.WithAnnotation(&v2.V1Identifier{
-				Id: fmt.Sprintf("repo:%s:role:%s", resource.Id.Resource, level),
-			}),
+		rv = append(rv, entitlement.NewPermissionEntitlement(nil, level,
+			entitlement.WithDisplayName(fmt.Sprintf("Repo %s", titleCase(level))),
+			entitlement.WithDescription(fmt.Sprintf("Access to repository in GitHub as %s", level)),
 			entitlement.WithGrantableTo(resourceTypeUser, resourceTypeTeam),
 		))
 	}

--- a/pkg/connector/team.go
+++ b/pkg/connector/team.go
@@ -137,20 +137,19 @@ func (o *teamResourceType) List(ctx context.Context, parentID *v2.ResourceId, op
 }
 
 func (o *teamResourceType) Entitlements(_ context.Context, resource *v2.Resource, _ rType.SyncOpAttrs) ([]*v2.Entitlement, *rType.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+func (o *teamResourceType) StaticEntitlements(_ context.Context, _ rType.SyncOpAttrs) ([]*v2.Entitlement, *rType.SyncOpResults, error) {
 	rv := make([]*v2.Entitlement, 0, len(teamAccessLevels))
 	for _, level := range teamAccessLevels {
 		rv = append(
 			rv,
 			entitlement.NewPermissionEntitlement(
-				resource,
+				nil,
 				level,
-				entitlement.WithAnnotation(
-					&v2.V1Identifier{
-						Id: fmt.Sprintf("team:%s:role:%s", resource.Id.Resource, level),
-					},
-				),
-				entitlement.WithDisplayName(fmt.Sprintf("%s Team %s", resource.DisplayName, titleCase(level))),
-				entitlement.WithDescription(fmt.Sprintf("Access to %s team in GitHub", resource.DisplayName)),
+				entitlement.WithDisplayName(fmt.Sprintf("Team %s", titleCase(level))),
+				entitlement.WithDescription(fmt.Sprintf("Access to team in GitHub as %s", level)),
 				entitlement.WithGrantableTo(resourceTypeUser),
 			),
 		)


### PR DESCRIPTION
This PR refactors the Entitlements implementation for Org, Team, Repository, OrgRole, and EnterpriseRole to use StaticEntitlements.

By moving these to static templates, we reduce the number of tasks generated during a sync, as the SDK can now define these entitlements once per resource type instead of per resource instance. This is especially impactful for connectors with a large number of repositories or teams.