### PR TITLE
Adds fetching expired invitations so we can track when an invitaiton is invalid in C1

### DIFF
--- a/pkg/connector/invitation.go
+++ b/pkg/connector/invitation.go
@@ -7,20 +7,53 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
+	"github.com/conductorone/baton-sdk/pkg/pagination"
 	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/google/go-github/v69/github"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 )
 
-func invitationToUserResource(invitation *github.Invitation) (*v2.Resource, error) {
+const (
+	// Profile keys for invitation status metadata.
+	invitationProfileKeyStatus    = "invitation_status"
+	invitationProfileKeyExpiresAt = "invitation_expires_at"
+
+	// Values exposed via invitation_status.
+	invitationStatusPendingAcceptance = "invitation_pending_acceptance"
+	invitationStatusExpired           = "invitation_expired"
+
+	// Pagination bag states used to drive the two upstream listing endpoints.
+	invitationStatePending = "invitation:pending"
+	invitationStateFailed  = "invitation:failed"
+
+	// GitHub returns the literal string "expired" in failed_reason when an
+	// invitation has expired without being accepted.
+	githubInvitationFailedReasonExpired = "expired"
+
+	// Organization invitations expire 7 days after creation.
+	// https://github.blog/changelog/2020-02-05-self-expiring-repository-and-organization-invitations/
+	invitationLifetime = 7 * 24 * time.Hour
+)
+
+func invitationToUserResource(invitation *github.Invitation, status string) (*v2.Resource, error) {
 	login := invitation.GetLogin()
 	if login == "" {
 		login = invitation.GetEmail()
+	}
+
+	profile := map[string]interface{}{
+		"login":                    login,
+		"inviter":                  invitation.GetInviter().GetLogin(),
+		invitationProfileKeyStatus: status,
+	}
+	if expiresAt, ok := invitationExpiresAt(invitation, status); ok {
+		profile[invitationProfileKeyExpiresAt] = expiresAt.UTC().Format(time.RFC3339)
 	}
 
 	ret, err := resourceSdk.NewUserResource(
@@ -29,10 +62,7 @@ func invitationToUserResource(invitation *github.Invitation) (*v2.Resource, erro
 		invitation.GetID(),
 		[]resourceSdk.UserTraitOption{
 			resourceSdk.WithEmail(invitation.GetEmail(), true),
-			resourceSdk.WithUserProfile(map[string]interface{}{
-				"login":   login,
-				"inviter": invitation.GetInviter().GetLogin(),
-			}),
+			resourceSdk.WithUserProfile(profile),
 			resourceSdk.WithStatus(v2.UserTrait_Status_STATUS_UNSPECIFIED),
 			resourceSdk.WithUserLogin(login),
 		},
@@ -41,6 +71,22 @@ func invitationToUserResource(invitation *github.Invitation) (*v2.Resource, erro
 		return nil, err
 	}
 	return ret, nil
+}
+
+// invitationExpiresAt returns the moment the invitation expired (for already
+// expired invitations) or will expire (for pending invitations). GitHub does
+// not surface an expires_at field on the org invitation payload, so for
+// pending invitations we derive it from created_at + 7 days.
+func invitationExpiresAt(invitation *github.Invitation, status string) (time.Time, bool) {
+	if status == invitationStatusExpired {
+		if t := invitation.GetFailedAt(); !t.IsZero() {
+			return t.Time, true
+		}
+	}
+	if t := invitation.GetCreatedAt(); !t.IsZero() {
+		return t.Add(invitationLifetime), true
+	}
+	return time.Time{}, false
 }
 
 type invitationResourceType struct {
@@ -54,7 +100,6 @@ func (i *invitationResourceType) ResourceType(_ context.Context) *v2.ResourceTyp
 }
 
 func (i *invitationResourceType) List(ctx context.Context, parentID *v2.ResourceId, opts resourceSdk.SyncOpAttrs) ([]*v2.Resource, *resourceSdk.SyncOpResults, error) {
-	var annotations annotations.Annotations
 	if parentID == nil {
 		return nil, &resourceSdk.SyncOpResults{}, nil
 	}
@@ -68,44 +113,106 @@ func (i *invitationResourceType) List(ctx context.Context, parentID *v2.Resource
 	if err != nil {
 		return nil, nil, err
 	}
-	invitations, resp, err := i.client.Organizations.ListPendingOrgInvitations(ctx, orgName, &github.ListOptions{
+
+	listOpts := &github.ListOptions{
 		Page:    page,
 		PerPage: opts.PageToken.Size,
-	})
-	if err != nil {
-		if isNotFoundError(resp) {
-			return nil, &resourceSdk.SyncOpResults{}, nil
+	}
+
+	var (
+		invitationResources []*v2.Resource
+		respAnnos           annotations.Annotations
+	)
+
+	switch bag.ResourceTypeID() {
+	case resourceTypeInvitation.Id:
+		// First call: fan out into the two listing states. Pending is pushed
+		// last so it is processed first; failed/expired runs after pending
+		// fully drains.
+		bag.Pop()
+		bag.Push(pagination.PageState{ResourceTypeID: invitationStateFailed})
+		bag.Push(pagination.PageState{ResourceTypeID: invitationStatePending})
+
+	case invitationStatePending:
+		invitations, resp, err := i.client.Organizations.ListPendingOrgInvitations(ctx, orgName, listOpts)
+		if err != nil {
+			if isNotFoundError(resp) {
+				if err := bag.Next(""); err != nil {
+					return nil, nil, err
+				}
+				break
+			}
+			return nil, nil, wrapGitHubError(err, resp, "github-connector: failed to list pending org invitations")
 		}
-		return nil, nil, wrapGitHubError(err, resp, "github-connector: failed to list pending org invitations")
-	}
 
-	restApiRateLimit, err := extractRateLimitData(resp)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	nextPage, _, err := parseResp(resp)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	pageToken, err := bag.NextToken(nextPage)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	invitationResources := make([]*v2.Resource, 0, len(invitations))
-	for _, invitation := range invitations {
-		ir, err := invitationToUserResource(invitation)
+		nextPage, annos, err := parseResp(resp)
 		if err != nil {
 			return nil, nil, err
 		}
-		invitationResources = append(invitationResources, ir)
+		respAnnos = annos
+
+		if err := bag.Next(nextPage); err != nil {
+			return nil, nil, err
+		}
+
+		invitationResources = make([]*v2.Resource, 0, len(invitations))
+		for _, invitation := range invitations {
+			ir, err := invitationToUserResource(invitation, invitationStatusPendingAcceptance)
+			if err != nil {
+				return nil, nil, err
+			}
+			invitationResources = append(invitationResources, ir)
+		}
+
+	case invitationStateFailed:
+		invitations, resp, err := i.client.Organizations.ListFailedOrgInvitations(ctx, orgName, listOpts)
+		if err != nil {
+			if isNotFoundError(resp) {
+				if err := bag.Next(""); err != nil {
+					return nil, nil, err
+				}
+				break
+			}
+			return nil, nil, wrapGitHubError(err, resp, "github-connector: failed to list failed org invitations")
+		}
+
+		nextPage, annos, err := parseResp(resp)
+		if err != nil {
+			return nil, nil, err
+		}
+		respAnnos = annos
+
+		if err := bag.Next(nextPage); err != nil {
+			return nil, nil, err
+		}
+
+		invitationResources = make([]*v2.Resource, 0, len(invitations))
+		for _, invitation := range invitations {
+			// The failed_invitations endpoint includes failures other than
+			// expirations (e.g. user_was_inactive, unexpected_failure). Only
+			// surface invitations that explicitly expired.
+			if invitation.GetFailedReason() != githubInvitationFailedReasonExpired {
+				continue
+			}
+			ir, err := invitationToUserResource(invitation, invitationStatusExpired)
+			if err != nil {
+				return nil, nil, err
+			}
+			invitationResources = append(invitationResources, ir)
+		}
+
+	default:
+		return nil, nil, fmt.Errorf("github-connector: unexpected invitation page state %q", bag.ResourceTypeID())
 	}
-	annotations.WithRateLimiting(restApiRateLimit)
+
+	pageToken, err := bag.Marshal()
+	if err != nil {
+		return nil, nil, err
+	}
+
 	return invitationResources, &resourceSdk.SyncOpResults{
 		NextPageToken: pageToken,
-		Annotations:   annotations,
+		Annotations:   respAnnos,
 	}, nil
 }
 
@@ -195,7 +302,7 @@ func (i *invitationResourceType) CreateAccount(
 	var annotations annotations.Annotations
 	annotations.WithRateLimiting(restApiRateLimit)
 
-	r, err := invitationToUserResource(invitation)
+	r, err := invitationToUserResource(invitation, invitationStatusPendingAcceptance)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("github-connectorv2: cannot create user resource: %w", err)
 	}
@@ -315,7 +422,7 @@ func (i *invitationResourceType) lookupPendingInvitation(ctx context.Context, or
 		}
 		for _, inv := range invitations {
 			if invitationMatches(inv, login, email) {
-				return invitationToUserResource(inv)
+				return invitationToUserResource(inv, invitationStatusPendingAcceptance)
 			}
 		}
 		if resp.NextPage == 0 {

--- a/pkg/connector/invitation.go
+++ b/pkg/connector/invitation.go
@@ -336,6 +336,12 @@ func (i *invitationResourceType) Delete(ctx context.Context, resourceId *v2.Reso
 		resp, err = i.client.Organizations.CancelInvite(ctx, org, invitationID)
 		if err == nil {
 			isRemoved = true
+			continue
+		}
+		if isNotFoundError(resp) {
+			// Invitation is already gone (expired or previously cancelled).
+			// Desired state is achieved, so treat as success.
+			isRemoved = true
 		}
 	}
 

--- a/pkg/connector/invitation_test.go
+++ b/pkg/connector/invitation_test.go
@@ -1,0 +1,259 @@
+package connector
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/pagination"
+	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/google/go-github/v69/github"
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-github/test/mocks"
+)
+
+const (
+	invitationTestOrgID    = int64(12)
+	invitationTestOrgLogin = "test-org-12"
+)
+
+// invitationListAll drives invitationResourceType.List in a loop, marshalling
+// the NextPageToken back in each iteration the way the SDK does at runtime,
+// and returns every resource the connector produced across all pages of both
+// underlying endpoints. The 50-iteration cap is a circuit breaker that fails
+// loudly if pagination ever fails to terminate.
+func invitationListAll(t *testing.T, ctx context.Context, b *invitationResourceType, parentID *v2.ResourceId) []*v2.Resource {
+	t.Helper()
+	var (
+		all   []*v2.Resource
+		token string
+	)
+	for i := 0; i < 50; i++ {
+		resources, results, err := b.List(ctx, parentID, resourceSdk.SyncOpAttrs{
+			PageToken: pagination.Token{Token: token},
+			Session:   &noOpSessionStore{},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, results)
+		all = append(all, resources...)
+		if results.NextPageToken == "" {
+			return all
+		}
+		token = results.NextPageToken
+	}
+	t.Fatalf("invitation List did not terminate within 50 iterations")
+	return nil
+}
+
+// orgByIDHandler responds to Organizations.GetByID with a fixed stub. The
+// invitation builder's orgCache calls this to resolve the parent resource ID
+// (a numeric string) to an org login for the URL path.
+func orgByIDHandler() mock.MockBackendOption {
+	return mock.WithRequestMatchHandler(
+		mocks.GetOrganizationById,
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write(mock.MustMarshal(github.Organization{
+				ID:    github.Ptr(invitationTestOrgID),
+				Login: github.Ptr(invitationTestOrgLogin),
+			}))
+		}),
+	)
+}
+
+func notFoundHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+}
+
+func TestInvitationListPagination(t *testing.T) {
+	ctx := context.Background()
+	parentID := &v2.ResourceId{
+		ResourceType: resourceTypeOrg.Id,
+		Resource:     "12",
+	}
+
+	// Fixed timestamps so expires_at assertions are deterministic.
+	pendingCreated1 := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	pendingCreated2 := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+	pendingCreated3 := time.Date(2026, 1, 3, 12, 0, 0, 0, time.UTC)
+	expiredFailedAt1 := time.Date(2026, 1, 4, 12, 0, 0, 0, time.UTC)
+	expiredFailedAt2 := time.Date(2026, 1, 5, 12, 0, 0, 0, time.UTC)
+
+	pendingPage1 := []*github.Invitation{
+		{
+			ID:        github.Ptr(int64(1001)),
+			Login:     github.Ptr("alice"),
+			Email:     github.Ptr("alice@example.com"),
+			Inviter:   &github.User{Login: github.Ptr("admin")},
+			CreatedAt: &github.Timestamp{Time: pendingCreated1},
+		},
+		{
+			ID:        github.Ptr(int64(1002)),
+			Login:     github.Ptr("bob"),
+			Email:     github.Ptr("bob@example.com"),
+			Inviter:   &github.User{Login: github.Ptr("admin")},
+			CreatedAt: &github.Timestamp{Time: pendingCreated2},
+		},
+	}
+	pendingPage2 := []*github.Invitation{
+		{
+			ID:        github.Ptr(int64(1003)),
+			Login:     github.Ptr("carol"),
+			Email:     github.Ptr("carol@example.com"),
+			Inviter:   &github.User{Login: github.Ptr("admin")},
+			CreatedAt: &github.Timestamp{Time: pendingCreated3},
+		},
+	}
+
+	// failedPage1 mixes an actually-expired invitation with one whose
+	// failed_reason is something else; only the expired one should be kept.
+	failedPage1 := []*github.Invitation{
+		{
+			ID:           github.Ptr(int64(2001)),
+			Email:        github.Ptr("dave-expired@example.com"),
+			Inviter:      &github.User{Login: github.Ptr("admin")},
+			CreatedAt:    &github.Timestamp{Time: pendingCreated1},
+			FailedAt:     &github.Timestamp{Time: expiredFailedAt1},
+			FailedReason: github.Ptr("expired"),
+		},
+		{
+			ID:           github.Ptr(int64(2002)),
+			Email:        github.Ptr("eve-inactive@example.com"),
+			Inviter:      &github.User{Login: github.Ptr("admin")},
+			CreatedAt:    &github.Timestamp{Time: pendingCreated1},
+			FailedAt:     &github.Timestamp{Time: expiredFailedAt1},
+			FailedReason: github.Ptr("user_was_inactive"),
+		},
+	}
+	failedPage2 := []*github.Invitation{
+		{
+			ID:           github.Ptr(int64(2003)),
+			Email:        github.Ptr("frank-expired@example.com"),
+			Inviter:      &github.User{Login: github.Ptr("admin")},
+			CreatedAt:    &github.Timestamp{Time: pendingCreated2},
+			FailedAt:     &github.Timestamp{Time: expiredFailedAt2},
+			FailedReason: github.Ptr("expired"),
+		},
+		{
+			ID:           github.Ptr(int64(2004)),
+			Email:        github.Ptr("grace-unexpected@example.com"),
+			Inviter:      &github.User{Login: github.Ptr("admin")},
+			CreatedAt:    &github.Timestamp{Time: pendingCreated2},
+			FailedAt:     &github.Timestamp{Time: expiredFailedAt2},
+			FailedReason: github.Ptr("unexpected_failure"),
+		},
+	}
+
+	newBuilder := func(httpClient *http.Client) *invitationResourceType {
+		gh := github.NewClient(httpClient)
+		return invitationBuilder(invitationBuilderParams{
+			client:   gh,
+			orgCache: newOrgNameCache(gh),
+			orgs:     []string{invitationTestOrgLogin},
+		})
+	}
+
+	t.Run("walks both endpoints across page boundaries", func(t *testing.T) {
+		client := mock.NewMockedHTTPClient(
+			orgByIDHandler(),
+			mock.WithRequestMatchPages(
+				mock.GetOrgsInvitationsByOrg,
+				pendingPage1, pendingPage2,
+			),
+			mock.WithRequestMatchPages(
+				mock.GetOrgsFailedInvitationsByOrg,
+				failedPage1, failedPage2,
+			),
+		)
+
+		got := invitationListAll(t, ctx, newBuilder(client), parentID)
+
+		// 3 pending (alice/bob/carol) + 2 expired-failed (dave/frank).
+		// user_was_inactive and unexpected_failure must be filtered out.
+		require.Len(t, got, 5, "expected 3 pending + 2 expired-failed; non-expired failed_reasons must be dropped")
+
+		byID := map[string]*v2.Resource{}
+		for _, r := range got {
+			byID[r.Id.Resource] = r
+		}
+		require.Contains(t, byID, "1001")
+		require.Contains(t, byID, "1002")
+		require.Contains(t, byID, "1003")
+		require.Contains(t, byID, "2001")
+		require.Contains(t, byID, "2003")
+		require.NotContains(t, byID, "2002", "user_was_inactive must be dropped")
+		require.NotContains(t, byID, "2004", "unexpected_failure must be dropped")
+
+		// Pending resources carry status=pending and expires_at = created_at + 7d.
+		aliceProfile := invitationProfile(t, byID["1001"])
+		require.Equal(t, invitationStatusPendingAcceptance, aliceProfile["invitation_status"])
+		require.Equal(t,
+			pendingCreated1.Add(invitationLifetime).UTC().Format(time.RFC3339),
+			aliceProfile["invitation_expires_at"],
+		)
+
+		// Expired resources carry status=expired and expires_at = failed_at.
+		daveProfile := invitationProfile(t, byID["2001"])
+		require.Equal(t, invitationStatusExpired, daveProfile["invitation_status"])
+		require.Equal(t,
+			expiredFailedAt1.UTC().Format(time.RFC3339),
+			daveProfile["invitation_expires_at"],
+		)
+	})
+
+	t.Run("pending 404 falls through to failed", func(t *testing.T) {
+		client := mock.NewMockedHTTPClient(
+			orgByIDHandler(),
+			mock.WithRequestMatchHandler(mock.GetOrgsInvitationsByOrg, notFoundHandler()),
+			mock.WithRequestMatchPages(mock.GetOrgsFailedInvitationsByOrg, failedPage1),
+		)
+
+		got := invitationListAll(t, ctx, newBuilder(client), parentID)
+		// Pending 404'd, only the one expired entry from failedPage1 survives.
+		require.Len(t, got, 1)
+		require.Equal(t, "2001", got[0].Id.Resource)
+		require.Equal(t, invitationStatusExpired,
+			invitationProfile(t, got[0])["invitation_status"])
+	})
+
+	t.Run("failed 404 terminates cleanly", func(t *testing.T) {
+		client := mock.NewMockedHTTPClient(
+			orgByIDHandler(),
+			mock.WithRequestMatchPages(mock.GetOrgsInvitationsByOrg, pendingPage1),
+			mock.WithRequestMatchHandler(mock.GetOrgsFailedInvitationsByOrg, notFoundHandler()),
+		)
+
+		got := invitationListAll(t, ctx, newBuilder(client), parentID)
+		// Pending: 2 invitations. Failed: 404, contributes nothing.
+		require.Len(t, got, 2)
+		require.Equal(t, invitationStatusPendingAcceptance,
+			invitationProfile(t, got[0])["invitation_status"])
+	})
+
+	t.Run("both endpoints empty terminates without API errors", func(t *testing.T) {
+		client := mock.NewMockedHTTPClient(
+			orgByIDHandler(),
+			mock.WithRequestMatchPages(mock.GetOrgsInvitationsByOrg, []*github.Invitation{}),
+			mock.WithRequestMatchPages(mock.GetOrgsFailedInvitationsByOrg, []*github.Invitation{}),
+		)
+
+		got := invitationListAll(t, ctx, newBuilder(client), parentID)
+		require.Empty(t, got)
+	})
+}
+
+// invitationProfile fetches the UserTrait profile from a synced invitation
+// resource and returns it as a map for easy assertion.
+func invitationProfile(t *testing.T, r *v2.Resource) map[string]any {
+	t.Helper()
+	ut, err := resourceSdk.GetUserTrait(r)
+	require.NoError(t, err)
+	require.NotNil(t, ut)
+	require.NotNil(t, ut.Profile)
+	return ut.Profile.AsMap()
+}


### PR DESCRIPTION
Customers want to be able to auto revoke invitations if they expire so users don't take up unused seats.