### PR TITLE
[CXP-527] Refresh GitHub App installation token on 401

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -270,10 +270,7 @@ func newGitHubClient(ctx context.Context, instanceURL string, ts oauth2.TokenSou
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
 
 	tc := oauth2.NewClient(ctx, ts)
-	if oauthT, ok := tc.Transport.(*oauth2.Transport); ok {
-		oauthT.Base = &unauthorized401Logger{base: oauthT.Base}
-	}
-	wrapWithUnauthorizedRefresh(tc, ts)
+	wrap401Handlers(tc, ts)
 	gc := github.NewClient(tc)
 
 	instanceURL = strings.TrimSuffix(instanceURL, "/")
@@ -422,10 +419,7 @@ func newGitHubGraphqlClient(ctx context.Context, instanceURL string, ts oauth2.T
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
 
 	tc := oauth2.NewClient(ctx, ts)
-	if oauthT, ok := tc.Transport.(*oauth2.Transport); ok {
-		oauthT.Base = &unauthorized401Logger{base: oauthT.Base}
-	}
-	wrapWithUnauthorizedRefresh(tc, ts)
+	wrap401Handlers(tc, ts)
 
 	instanceURL = strings.TrimSuffix(instanceURL, "/")
 	if instanceURL != "" && instanceURL != githubDotCom {
@@ -645,8 +639,13 @@ func (t *unauthorizedRefreshTransport) RoundTrip(req *http.Request) (*http.Respo
 	return t.base.RoundTrip(retry)
 }
 
-// wrapWithUnauthorizedRefresh adds the 401-retry layer if ts supports invalidation.
-func wrapWithUnauthorizedRefresh(c *http.Client, ts oauth2.TokenSource) {
+// wrap401Handlers attaches diagnostic logging beneath oauth2.Transport and the
+// 401-retry layer above it. The logger is installed unconditionally; the retry
+// only when ts supports invalidation (PAT and JWT-only sources don't).
+func wrap401Handlers(c *http.Client, ts oauth2.TokenSource) {
+	if oauthT, ok := c.Transport.(*oauth2.Transport); ok {
+		oauthT.Base = &unauthorized401Logger{base: oauthT.Base}
+	}
 	if inv, ok := ts.(tokenInvalidator); ok {
 		c.Transport = &unauthorizedRefreshTransport{base: c.Transport, src: inv}
 	}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -619,6 +619,17 @@ func (t *unauthorizedRefreshTransport) RoundTrip(req *http.Request) (*http.Respo
 		return resp, nil
 	}
 
+	// Rebuild the request body before touching the 401 response so the
+	// GetBody-error path can return resp with a readable body.
+	var retryBody io.ReadCloser
+	if req.GetBody != nil {
+		body, gErr := req.GetBody()
+		if gErr != nil {
+			return resp, nil //nolint:nilerr // gErr is incidental; surface the 401
+		}
+		retryBody = body
+	}
+
 	_, _ = io.Copy(io.Discard, resp.Body)
 	_ = resp.Body.Close()
 
@@ -629,14 +640,8 @@ func (t *unauthorizedRefreshTransport) RoundTrip(req *http.Request) (*http.Respo
 	)
 
 	retry := req.Clone(req.Context())
-	if req.GetBody != nil {
-		body, gErr := req.GetBody()
-		if gErr != nil {
-			// Can't rebuild the body — fall back to the original 401 response
-			// rather than fail the request outright; gErr is incidental.
-			return resp, nil //nolint:nilerr // see comment above
-		}
-		retry.Body = body
+	if retryBody != nil {
+		retry.Body = retryBody
 	}
 	return t.base.RoundTrip(retry)
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -1,6 +1,7 @@
 package connector
 
 import (
+	"bytes"
 	"context"
 	"crypto/rsa"
 	"crypto/x509"
@@ -269,6 +270,9 @@ func newGitHubClient(ctx context.Context, instanceURL string, ts oauth2.TokenSou
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
 
 	tc := oauth2.NewClient(ctx, ts)
+	if oauthT, ok := tc.Transport.(*oauth2.Transport); ok {
+		oauthT.Base = &unauthorized401Logger{base: oauthT.Base}
+	}
 	wrapWithUnauthorizedRefresh(tc, ts)
 	gc := github.NewClient(tc)
 
@@ -418,6 +422,9 @@ func newGitHubGraphqlClient(ctx context.Context, instanceURL string, ts oauth2.T
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
 
 	tc := oauth2.NewClient(ctx, ts)
+	if oauthT, ok := tc.Transport.(*oauth2.Transport); ok {
+		oauthT.Base = &unauthorized401Logger{base: oauthT.Base}
+	}
 	wrapWithUnauthorizedRefresh(tc, ts)
 
 	instanceURL = strings.TrimSuffix(instanceURL, "/")
@@ -643,6 +650,75 @@ func wrapWithUnauthorizedRefresh(c *http.Client, ts oauth2.TokenSource) {
 	if inv, ok := ts.(tokenInvalidator); ok {
 		c.Transport = &unauthorizedRefreshTransport{base: c.Transport, src: inv}
 	}
+}
+
+// unauthorized401Logger is a diagnostic-only RoundTripper that emits a single
+// DEBUG line on every 401 response, capturing rate-limit headers, the GitHub
+// request id, the response body, and a fingerprint of the token in use. It
+// does not alter the response.
+type unauthorized401Logger struct {
+	base http.RoundTripper
+}
+
+var diagnostic401Headers = []string{
+	"X-Github-Request-Id",
+	"X-Ratelimit-Limit",
+	"X-Ratelimit-Remaining",
+	"X-Ratelimit-Reset",
+	"X-Ratelimit-Used",
+	"X-Ratelimit-Resource",
+	"Retry-After",
+}
+
+func (t *unauthorized401Logger) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt := t.base
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+	resp, err := rt.RoundTrip(req)
+	if err != nil || resp == nil || resp.StatusCode != http.StatusUnauthorized {
+		return resp, err
+	}
+
+	var body []byte
+	if resp.Body != nil {
+		body, _ = io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+	}
+
+	headers := make(map[string]string, len(diagnostic401Headers))
+	for _, h := range diagnostic401Headers {
+		if v := resp.Header.Get(h); v != "" {
+			headers[h] = v
+		}
+	}
+
+	ctxzap.Extract(req.Context()).Debug("github-connector: received 401 response",
+		zap.String("http.method", req.Method),
+		zap.String("http.url_details.path", req.URL.Path),
+		zap.String("http.url_details.query", req.URL.RawQuery),
+		zap.Any("response_headers", headers),
+		zap.String("response_body", string(body)),
+		zap.String("token_fingerprint", tokenFingerprint(req.Header.Get("Authorization"))),
+	)
+
+	return resp, err
+}
+
+// tokenFingerprint returns the first/last four characters of the bearer
+// portion of an Authorization header so log readers can tell whether the same
+// token is being used across requests without exposing the full secret.
+func tokenFingerprint(authHeader string) string {
+	parts := strings.SplitN(authHeader, " ", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	tok := parts[1]
+	if len(tok) < 8 {
+		return ""
+	}
+	return tok[:4] + "..." + tok[len(tok)-4:]
 }
 
 func getOrgs(ctx context.Context, client *github.Client, orgs []string) ([]string, error) {

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -551,12 +551,8 @@ func (r *appTokenRefresher) Token() (*oauth2.Token, error) {
 	}, nil
 }
 
-// refreshableTokenSource is like oauth2.ReuseTokenSource but exposes
-// Invalidate() so a 401 response can force a refresh on the next call even
-// when the cached token has not yet reached its stated expiry. GitHub App
-// installation tokens can become invalid before the 1h mark (e.g. app
-// reinstall, permission change), and without this the entire long-running
-// sync fails until the natural refresh window arrives.
+// refreshableTokenSource is an oauth2.TokenSource whose cache can be cleared
+// externally, so a 401 can force a refresh before the cached token's expiry.
 type refreshableTokenSource struct {
 	mu      sync.Mutex
 	cur     *oauth2.Token
@@ -581,29 +577,25 @@ func (r *refreshableTokenSource) Token() (*oauth2.Token, error) {
 	return t, nil
 }
 
-// Invalidate clears the cached token, forcing the next Token() call to
-// refresh. Safe to call from any goroutine.
+// Invalidate clears the cached token if it still matches prev. The match check
+// prevents concurrent 401s on the same stale token from triggering redundant
+// refreshes.
 func (r *refreshableTokenSource) Invalidate(prev *oauth2.Token) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	// Only invalidate if the cached token matches the one the caller saw fail.
-	// Otherwise we'd thrash when many in-flight requests all 401 on the same
-	// stale token and then race to clear an already-refreshed token.
 	if prev != nil && r.cur != nil && r.cur.AccessToken != prev.AccessToken {
 		return
 	}
 	r.cur = nil
 }
 
-// tokenInvalidator is implemented by token sources that allow forcing a
-// refresh on the next Token() call.
+// tokenInvalidator is a TokenSource whose cache can be cleared externally.
 type tokenInvalidator interface {
-	Invalidate(prev *oauth2.Token)
 	Token() (*oauth2.Token, error)
+	Invalidate(prev *oauth2.Token)
 }
 
-// unauthorizedRefreshTransport retries an idempotent request once after a 401
-// response, invalidating the cached token first so the retry uses a fresh one.
+// unauthorizedRefreshTransport retries a 401 response once with a refreshed token.
 type unauthorizedRefreshTransport struct {
 	base http.RoundTripper
 	src  tokenInvalidator
@@ -619,8 +611,8 @@ func (t *unauthorizedRefreshTransport) RoundTrip(req *http.Request) (*http.Respo
 		return resp, nil
 	}
 
-	// Rebuild the request body before touching the 401 response so the
-	// GetBody-error path can return resp with a readable body.
+	// Reproduce the body before draining the 401, so the GetBody-error path can
+	// return resp with a still-readable body.
 	var retryBody io.ReadCloser
 	if req.GetBody != nil {
 		body, gErr := req.GetBody()
@@ -646,16 +638,11 @@ func (t *unauthorizedRefreshTransport) RoundTrip(req *http.Request) (*http.Respo
 	return t.base.RoundTrip(retry)
 }
 
-// wrapWithUnauthorizedRefresh wraps the http.Client's transport with retry
-// logic when the supplied TokenSource supports invalidation. PAT-based and
-// JWT-only token sources don't implement Invalidate, so they pass through
-// unchanged.
+// wrapWithUnauthorizedRefresh adds the 401-retry layer if ts supports invalidation.
 func wrapWithUnauthorizedRefresh(c *http.Client, ts oauth2.TokenSource) {
-	inv, ok := ts.(tokenInvalidator)
-	if !ok {
-		return
+	if inv, ok := ts.(tokenInvalidator); ok {
+		c.Transport = &unauthorizedRefreshTransport{base: c.Transport, src: inv}
 	}
-	c.Transport = &unauthorizedRefreshTransport{base: c.Transport, src: inv}
 }
 
 func getOrgs(ctx context.Context, client *github.Client, orgs []string) ([]string, error) {

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	cfg "github.com/conductorone/baton-github/pkg/config"
@@ -268,6 +269,7 @@ func newGitHubClient(ctx context.Context, instanceURL string, ts oauth2.TokenSou
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
 
 	tc := oauth2.NewClient(ctx, ts)
+	wrapWithUnauthorizedRefresh(tc, ts)
 	gc := github.NewClient(tc)
 
 	instanceURL = strings.TrimSuffix(instanceURL, "/")
@@ -361,7 +363,7 @@ func newWithGithubApp(ctx context.Context, ghc *cfg.Github) (*GitHub, error) {
 			privateKey: string(ghc.AppPrivatekeyPath),
 		},
 	)
-	ts := oauth2.ReuseTokenSource(
+	ts := newRefreshableTokenSource(
 		&oauth2.Token{
 			AccessToken: token.GetToken(),
 			Expiry:      token.GetExpiresAt().Time,
@@ -416,6 +418,7 @@ func newGitHubGraphqlClient(ctx context.Context, instanceURL string, ts oauth2.T
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
 
 	tc := oauth2.NewClient(ctx, ts)
+	wrapWithUnauthorizedRefresh(tc, ts)
 
 	instanceURL = strings.TrimSuffix(instanceURL, "/")
 	if instanceURL != "" && instanceURL != githubDotCom {
@@ -546,6 +549,108 @@ func (r *appTokenRefresher) Token() (*oauth2.Token, error) {
 		AccessToken: token.GetToken(),
 		Expiry:      token.GetExpiresAt().Time,
 	}, nil
+}
+
+// refreshableTokenSource is like oauth2.ReuseTokenSource but exposes
+// Invalidate() so a 401 response can force a refresh on the next call even
+// when the cached token has not yet reached its stated expiry. GitHub App
+// installation tokens can become invalid before the 1h mark (e.g. app
+// reinstall, permission change), and without this the entire long-running
+// sync fails until the natural refresh window arrives.
+type refreshableTokenSource struct {
+	mu      sync.Mutex
+	cur     *oauth2.Token
+	refresh oauth2.TokenSource
+}
+
+func newRefreshableTokenSource(initial *oauth2.Token, refresh oauth2.TokenSource) *refreshableTokenSource {
+	return &refreshableTokenSource{cur: initial, refresh: refresh}
+}
+
+func (r *refreshableTokenSource) Token() (*oauth2.Token, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.cur.Valid() {
+		return r.cur, nil
+	}
+	t, err := r.refresh.Token()
+	if err != nil {
+		return nil, err
+	}
+	r.cur = t
+	return t, nil
+}
+
+// Invalidate clears the cached token, forcing the next Token() call to
+// refresh. Safe to call from any goroutine.
+func (r *refreshableTokenSource) Invalidate(prev *oauth2.Token) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// Only invalidate if the cached token matches the one the caller saw fail.
+	// Otherwise we'd thrash when many in-flight requests all 401 on the same
+	// stale token and then race to clear an already-refreshed token.
+	if prev != nil && r.cur != nil && r.cur.AccessToken != prev.AccessToken {
+		return
+	}
+	r.cur = nil
+}
+
+// tokenInvalidator is implemented by token sources that allow forcing a
+// refresh on the next Token() call.
+type tokenInvalidator interface {
+	Invalidate(prev *oauth2.Token)
+	Token() (*oauth2.Token, error)
+}
+
+// unauthorizedRefreshTransport retries an idempotent request once after a 401
+// response, invalidating the cached token first so the retry uses a fresh one.
+type unauthorizedRefreshTransport struct {
+	base http.RoundTripper
+	src  tokenInvalidator
+}
+
+func (t *unauthorizedRefreshTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	prev, _ := t.src.Token()
+	resp, err := t.base.RoundTrip(req)
+	if err != nil || resp == nil || resp.StatusCode != http.StatusUnauthorized {
+		return resp, err
+	}
+	if req.Body != nil && req.GetBody == nil {
+		return resp, nil
+	}
+
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	t.src.Invalidate(prev)
+	ctxzap.Extract(req.Context()).Info("github-connector: got 401, invalidating cached token and retrying once",
+		zap.String("http.method", req.Method),
+		zap.String("http.url_details.path", req.URL.Path),
+	)
+
+	retry := req.Clone(req.Context())
+	if req.GetBody != nil {
+		body, gErr := req.GetBody()
+		if gErr != nil {
+			// Can't rebuild the body — fall back to the original 401 response
+			// rather than fail the request outright; gErr is incidental.
+			return resp, nil //nolint:nilerr // see comment above
+		}
+		retry.Body = body
+	}
+	return t.base.RoundTrip(retry)
+}
+
+// wrapWithUnauthorizedRefresh wraps the http.Client's transport with retry
+// logic when the supplied TokenSource supports invalidation. PAT-based and
+// JWT-only token sources don't implement Invalidate, so they pass through
+// unchanged.
+func wrapWithUnauthorizedRefresh(c *http.Client, ts oauth2.TokenSource) {
+	inv, ok := ts.(tokenInvalidator)
+	if !ok {
+		return
+	}
+	c.Transport = &unauthorizedRefreshTransport{base: c.Transport, src: inv}
 }
 
 func getOrgs(ctx context.Context, client *github.Client, orgs []string) ([]string, error) {

--- a/pkg/connector/connector_test.go
+++ b/pkg/connector/connector_test.go
@@ -1,6 +1,7 @@
 package connector
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -210,4 +211,61 @@ func TestUnauthorizedRefreshTransport_DoesNotRetryWhenBodyCannotReplay(t *testin
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	require.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}
+
+func TestUnauthorized401Logger_PassesNon401ResponsesThrough(t *testing.T) {
+	calls := 0
+	base := rtFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("ok")), Header: http.Header{}}, nil
+	})
+	tr := &unauthorized401Logger{base: base}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.github.com/x", nil)
+	resp, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 1, calls)
+}
+
+func TestUnauthorized401Logger_PreservesResponseBodyOn401(t *testing.T) {
+	base := rtFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{"message":"Requires authentication"}`))),
+			Header: http.Header{
+				"X-Github-Request-Id":   []string{"ABCD:1234:5678"},
+				"X-Ratelimit-Remaining": []string{"4998"},
+			},
+		}, nil
+	})
+	tr := &unauthorized401Logger{base: base}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.github.com/x", nil)
+	req.Header.Set("Authorization", "Bearer ghs_abcdefghijklmnopqrst")
+	resp, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, `{"message":"Requires authentication"}`, string(body))
+}
+
+func TestTokenFingerprint(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"Bearer ghs_abcdefghijklmnopqrst", "ghs_...qrst"},
+		{"Bearer 12345678", "1234...5678"},
+		{"Bearer abc", ""},
+		{"", ""},
+		{"weirdvalueNoSpace", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			require.Equal(t, tc.want, tokenFingerprint(tc.in))
+		})
+	}
 }

--- a/pkg/connector/connector_test.go
+++ b/pkg/connector/connector_test.go
@@ -159,6 +159,37 @@ func TestUnauthorizedRefreshTransport_PassesThroughNon401(t *testing.T) {
 	require.Equal(t, 0, refresher.calls)
 }
 
+func TestUnauthorizedRefreshTransport_GetBodyErrorReturnsReadableResponse(t *testing.T) {
+	refresher := &stubRefresher{tokens: []string{"unused"}}
+	initial := &oauth2.Token{AccessToken: "initial", Expiry: time.Now().Add(time.Hour)}
+	src := newRefreshableTokenSource(initial, refresher)
+
+	var calls int32
+	base := rtFunc(func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&calls, 1)
+		return makeResp(http.StatusUnauthorized, "details about the 401"), nil
+	})
+	tr := &unauthorizedRefreshTransport{base: base, src: src}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://api.github.com/x", strings.NewReader("payload"))
+	require.NoError(t, err)
+	req.GetBody = func() (io.ReadCloser, error) {
+		return nil, errors.New("synthetic GetBody failure")
+	}
+
+	resp, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "must not retry when body cannot be rebuilt")
+
+	// Body must still be readable by the caller; the prior bug closed it.
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "details about the 401", string(body))
+	require.Equal(t, 0, refresher.calls, "token must not be invalidated when we couldn't retry")
+}
+
 func TestUnauthorizedRefreshTransport_DoesNotRetryWhenBodyCannotReplay(t *testing.T) {
 	refresher := &stubRefresher{tokens: []string{"unused"}}
 	initial := &oauth2.Token{AccessToken: "initial", Expiry: time.Now().Add(time.Hour)}

--- a/pkg/connector/connector_test.go
+++ b/pkg/connector/connector_test.go
@@ -1,0 +1,182 @@
+package connector
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+type stubRefresher struct {
+	mu     sync.Mutex
+	calls  int
+	tokens []string
+}
+
+func (s *stubRefresher) Token() (*oauth2.Token, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	if len(s.tokens) == 0 {
+		return nil, errors.New("no more tokens")
+	}
+	t := s.tokens[0]
+	s.tokens = s.tokens[1:]
+	return &oauth2.Token{AccessToken: t, Expiry: time.Now().Add(time.Hour)}, nil
+}
+
+func TestRefreshableTokenSource_ReusesCachedToken(t *testing.T) {
+	refresher := &stubRefresher{tokens: []string{"never-called"}}
+	src := newRefreshableTokenSource(
+		&oauth2.Token{AccessToken: "initial", Expiry: time.Now().Add(time.Hour)},
+		refresher,
+	)
+
+	for range 3 {
+		tok, err := src.Token()
+		require.NoError(t, err)
+		require.Equal(t, "initial", tok.AccessToken)
+	}
+	require.Equal(t, 0, refresher.calls)
+}
+
+func TestRefreshableTokenSource_RefreshesWhenExpired(t *testing.T) {
+	refresher := &stubRefresher{tokens: []string{"refreshed"}}
+	src := newRefreshableTokenSource(
+		&oauth2.Token{AccessToken: "initial", Expiry: time.Now().Add(-time.Minute)},
+		refresher,
+	)
+	tok, err := src.Token()
+	require.NoError(t, err)
+	require.Equal(t, "refreshed", tok.AccessToken)
+	require.Equal(t, 1, refresher.calls)
+}
+
+func TestRefreshableTokenSource_InvalidateForcesRefresh(t *testing.T) {
+	refresher := &stubRefresher{tokens: []string{"refreshed"}}
+	initial := &oauth2.Token{AccessToken: "initial", Expiry: time.Now().Add(time.Hour)}
+	src := newRefreshableTokenSource(initial, refresher)
+
+	src.Invalidate(initial)
+
+	tok, err := src.Token()
+	require.NoError(t, err)
+	require.Equal(t, "refreshed", tok.AccessToken)
+	require.Equal(t, 1, refresher.calls)
+}
+
+func TestRefreshableTokenSource_InvalidateIgnoresStaleToken(t *testing.T) {
+	refresher := &stubRefresher{tokens: []string{"second"}}
+	initial := &oauth2.Token{AccessToken: "first", Expiry: time.Now().Add(time.Hour)}
+	src := newRefreshableTokenSource(initial, refresher)
+
+	// Simulate the cache already advancing to "second" via expiry refresh.
+	src.cur = &oauth2.Token{AccessToken: "second", Expiry: time.Now().Add(time.Hour)}
+
+	// A stale caller still holds "first" and tries to invalidate; we must not
+	// clear the newer cached token.
+	src.Invalidate(initial)
+
+	tok, err := src.Token()
+	require.NoError(t, err)
+	require.Equal(t, "second", tok.AccessToken)
+	require.Equal(t, 0, refresher.calls)
+}
+
+type rtFunc func(*http.Request) (*http.Response, error)
+
+func (f rtFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func makeResp(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+func TestUnauthorizedRefreshTransport_RetriesOn401(t *testing.T) {
+	refresher := &stubRefresher{tokens: []string{"refreshed"}}
+	initial := &oauth2.Token{AccessToken: "initial", Expiry: time.Now().Add(time.Hour)}
+	src := newRefreshableTokenSource(initial, refresher)
+
+	var calls int32
+	var seenAuth []string
+	// Simulate oauth2.Transport: fetch a token on every request and 401 if the
+	// token isn't the refreshed one.
+	base := rtFunc(func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&calls, 1)
+		tok, err := src.Token()
+		if err != nil {
+			return nil, err
+		}
+		seenAuth = append(seenAuth, tok.AccessToken)
+		if tok.AccessToken != "refreshed" {
+			return makeResp(http.StatusUnauthorized, "nope"), nil
+		}
+		return makeResp(http.StatusOK, "ok"), nil
+	})
+	tr := &unauthorizedRefreshTransport{base: base, src: src}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.github.com/x", nil)
+	require.NoError(t, err)
+	resp, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, int32(2), atomic.LoadInt32(&calls))
+	require.Equal(t, []string{"initial", "refreshed"}, seenAuth)
+	require.Equal(t, 1, refresher.calls, "cache should have been invalidated and refreshed once")
+}
+
+func TestUnauthorizedRefreshTransport_PassesThroughNon401(t *testing.T) {
+	refresher := &stubRefresher{tokens: []string{"unused"}}
+	initial := &oauth2.Token{AccessToken: "initial", Expiry: time.Now().Add(time.Hour)}
+	src := newRefreshableTokenSource(initial, refresher)
+
+	var calls int32
+	base := rtFunc(func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&calls, 1)
+		return makeResp(http.StatusForbidden, "denied"), nil
+	})
+	tr := &unauthorizedRefreshTransport{base: base, src: src}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.github.com/x", nil)
+	require.NoError(t, err)
+	resp, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls))
+	require.Equal(t, 0, refresher.calls)
+}
+
+func TestUnauthorizedRefreshTransport_DoesNotRetryWhenBodyCannotReplay(t *testing.T) {
+	refresher := &stubRefresher{tokens: []string{"unused"}}
+	initial := &oauth2.Token{AccessToken: "initial", Expiry: time.Now().Add(time.Hour)}
+	src := newRefreshableTokenSource(initial, refresher)
+
+	var calls int32
+	base := rtFunc(func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&calls, 1)
+		return makeResp(http.StatusUnauthorized, "nope"), nil
+	})
+	tr := &unauthorizedRefreshTransport{base: base, src: src}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://api.github.com/x", strings.NewReader("payload"))
+	require.NoError(t, err)
+	req.GetBody = nil // simulate unbufferable body
+	resp, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}


### PR DESCRIPTION
## Summary

GitHub App installation tokens can become invalid before their stated 1-hour expiry (rotation, permission change, app reinstall). When this happens mid-sync, the entire long-running sync fails because `oauth2.ReuseTokenSource` only refreshes after the cached expiry passes. For large orgs whose sync takes hours/days, a single mid-flight 401 trashes the whole run.

This PR makes the connector treat 401 as a refresh signal: it invalidates the cached installation token and retries the request once with a fresh one.

## What changed

`pkg/connector/connector.go`

- **`refreshableTokenSource`** replaces `oauth2.ReuseTokenSource` for the installation token. Same caching behavior, plus an `Invalidate(prev *oauth2.Token)` method. The `prev` check ensures we only clear the cache if it still matches the token the caller saw fail — prevents concurrent 401s from thrashing an already-refreshed cache.
- **`unauthorizedRefreshTransport`** wraps the http.Client transport. On a 401: drains the body, calls `Invalidate(prev)`, logs once, and replays the request (using `GetBody` when present).
- **`wrapWithUnauthorizedRefresh`** is wired into both `newGitHubClient` and `newGitHubGraphqlClient`, so REST, GraphQL, and the customclient all benefit. It type-asserts the token source for the invalidator interface, so PAT (`oauth2.StaticTokenSource`) and the JWT-only `appClient` (which uses `oauth2.ReuseTokenSource` for the JWT, not the installation token) pass through unchanged.

`pkg/connector/connector_test.go` (new)

Covers cached-token reuse, expiry-triggered refresh, invalidate-forced refresh, stale-invalidate no-op, transport retry on 401, pass-through on non-401, and no-retry when the body can't be replayed.

## Context

- 14 days of 401s observed for one customer's GitHub v2 connector. Sample error: ``rpc error: code = Unauthenticated desc = github-connector: failed to list collaborators: GET /repos/.../collaborators: Requires authentication``. All occur during `SYNC_STEP_GRANTS`, mid-pagination on different repos each cycle.
- Today a single 401 mid-grants causes `syncer.Sync()` to return error → sync activity does not persist the c1z → next cycle restarts.
- See Linear CXP-527 for full investigation, including a separate 60s HTTP/2 timeout pattern and downstream c1z corruption (both out of scope for this PR).

## Risk

- Only affects the GitHub App auth code path; PAT users see no behavior change.
- Retry is bounded to one extra attempt per request.
- Retry skips requests with non-replayable bodies (those return the original 401 unchanged).
- Race between concurrent 401s on the same stale token is handled: only the first invalidation succeeds; the rest become no-ops via the `prev` token comparison.

## Test plan

- [x] `go test -race ./pkg/connector/`
- [x] `make lint`
- [ ] Manual: run a sync against a GitHub App-authed org with a freshly rotated installation token; verify the connector refreshes and continues instead of failing the run.