### PR TITLE
[CXP-527] Refresh GitHub App installation tokens 10m before stated expiry

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -35,6 +35,11 @@ const githubDotCom = "https://github.com"
 // JWT token expires in 10 minutes, so we set it to 9 minutes to leave some buffer.
 const jwtExpiryTime = 9 * time.Minute
 
+// installationTokenRefreshBuffer is subtracted from GitHub's stated expiry so
+// we refresh well before any worker/GitHub clock skew can make a cached token
+// look valid when it isn't. oauth2's default 10s delta is too tight.
+const installationTokenRefreshBuffer = 10 * time.Minute
+
 var (
 	ValidAssetDomains     = []string{"avatars.githubusercontent.com"}
 	maxPageSize       int = 100 // maximum page size github supported.
@@ -364,7 +369,7 @@ func newWithGithubApp(ctx context.Context, ghc *cfg.Github) (*GitHub, error) {
 	ts := oauth2.ReuseTokenSource(
 		&oauth2.Token{
 			AccessToken: token.GetToken(),
-			Expiry:      token.GetExpiresAt().Time,
+			Expiry:      bufferedInstallationTokenExpiry(token.GetExpiresAt().Time),
 		},
 		&appTokenRefresher{
 			ctx:            ctx,
@@ -544,8 +549,16 @@ func (r *appTokenRefresher) Token() (*oauth2.Token, error) {
 	}
 	return &oauth2.Token{
 		AccessToken: token.GetToken(),
-		Expiry:      token.GetExpiresAt().Time,
+		Expiry:      bufferedInstallationTokenExpiry(token.GetExpiresAt().Time),
 	}, nil
+}
+
+// Zero stated expiry returns time.Now() so the next call refreshes.
+func bufferedInstallationTokenExpiry(stated time.Time) time.Time {
+	if stated.IsZero() {
+		return time.Now()
+	}
+	return stated.Add(-installationTokenRefreshBuffer)
 }
 
 func getOrgs(ctx context.Context, client *github.Client, orgs []string) ([]string, error) {

--- a/pkg/connector/connector_test.go
+++ b/pkg/connector/connector_test.go
@@ -1,0 +1,40 @@
+package connector
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBufferedInstallationTokenExpiry(t *testing.T) {
+	t.Run("subtracts the refresh buffer from a normal stated expiry", func(t *testing.T) {
+		stated := time.Now().Add(60 * time.Minute)
+		got := bufferedInstallationTokenExpiry(stated)
+		require.Equal(t, stated.Add(-installationTokenRefreshBuffer), got)
+	})
+
+	t.Run("subtracts the refresh buffer from a short stated expiry too", func(t *testing.T) {
+		// 5m stated → buffer of 10m pushes result into the past, which is fine:
+		// oauth2 will treat the token as expired and refresh on next use.
+		stated := time.Now().Add(5 * time.Minute)
+		got := bufferedInstallationTokenExpiry(stated)
+		require.Equal(t, stated.Add(-installationTokenRefreshBuffer), got)
+		require.True(t, got.Before(time.Now()))
+	})
+
+	t.Run("subtracts the refresh buffer from a past stated expiry (still in the past)", func(t *testing.T) {
+		stated := time.Now().Add(-5 * time.Minute)
+		got := bufferedInstallationTokenExpiry(stated)
+		require.Equal(t, stated.Add(-installationTokenRefreshBuffer), got)
+	})
+
+	t.Run("zero stated expiry forces an immediate refresh", func(t *testing.T) {
+		before := time.Now()
+		got := bufferedInstallationTokenExpiry(time.Time{})
+		after := time.Now()
+		// Should land within the call window — no future expiry assumed.
+		require.False(t, got.Before(before))
+		require.False(t, got.After(after))
+	})
+}


### PR DESCRIPTION
## Summary

Subtract a 10-minute buffer from GitHub's stated expiry when caching a GitHub App installation token, so we refresh well before the boundary. Workaround for intermittent mid-sync 401s on still-cached tokens seen across ~40 prod connectors. Most plausible cause is clock skew between worker hosts and GitHub — oauth2's default 10s expiry-delta is too tight when clocks can drift by tens of seconds.

## What changed

`pkg/connector/connector.go`:
- New `installationTokenRefreshBuffer = 10 * time.Minute`.
- New `bufferedInstallationTokenExpiry` helper: returns `stated - buffer`. Zero stated expiry returns `time.Now()` so refresh fires immediately.
- Applied to the initial token in `newWithGithubApp` and refreshed tokens in `appTokenRefresher.Token`.

Tests cover normal expiry, short expiry (buffer pushes into past, refresh fires immediately), past expiry, zero expiry.

## Cost

~20% more `CreateInstallationToken` calls per warm connector instance. Well within GitHub's per-App rate budget.

## Test plan

- [x] `go test -race ./pkg/connector/`
- [x] `make lint`
- [ ] Deploy and verify mid-sync 401s drop on affected connectors.