### PR TITLE
docs: fix connector doc regressions

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -82,7 +82,7 @@ Click **Generate token**. Carefully copy and save the new token.
 If you use SAML SSO, you must authorize the PAT using [these instructions](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on).
 </Warning>
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ### Option 2: Use a fine-grained access token
 
@@ -140,7 +140,7 @@ Click **Generate token**. Carefully copy and save the new token.
 </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ### Option 3: Use a GitHub app
 
@@ -230,7 +230,7 @@ Click **Install**.
 </Step>
 </Steps> 
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the GitHub connector
 
@@ -306,7 +306,7 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your GitHub connector is now pulling access data into C1.
+**Done.** Your GitHub connector is now pulling access data into C1.
 </Tab>
 
 <Tab title="Self-hosted">
@@ -436,7 +436,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your GitHub connector is now pulling access data into C1.
+**Done.** Your GitHub connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

This PR corrects issues in the connector docs that were caught during a sync to the ConductorOne docs site. Specific fixes depend on the connector — may include one or more of:

- Restore `**Done.**` closing phrase (replaces `**That's it!**`)
- Restore full `ConductorOne*` names (replaces `C1*` abbreviations, e.g. `C1Integration`)
- Restore correct check icon color (`#c937ae`)
- Restore `BATON_PROVISIONING: true` flag in Kubernetes secrets block (with comment)
- Fix connector description to accurately reflect sync/provisioning capabilities

These corrections prevent the sync bot from reintroducing regressions on future runs.