### PR TITLE
CXP-539 Fix how expired invitations are identified

### DIFF
--- a/pkg/connector/invitation.go
+++ b/pkg/connector/invitation.go
@@ -191,9 +191,11 @@ func (i *invitationResourceType) List(ctx context.Context, parentID *v2.Resource
 			// The failed_invitations endpoint includes failures other than
 			// expirations (e.g. user_was_inactive, unexpected_failure). Only
 			// surface invitations that explicitly expired.
-			if invitation.GetFailedReason() != githubInvitationFailedReasonExpired {
+			failedReason := strings.ToLower(invitation.GetFailedReason())
+			if !strings.Contains(failedReason, githubInvitationFailedReasonExpired) {
 				continue
 			}
+
 			ir, err := invitationToUserResource(invitation, invitationStatusExpired)
 			if err != nil {
 				return nil, nil, err


### PR DESCRIPTION
Looks like the actual message returned for expired invites is: "Invitation expired. User did not accept this invite for 7 days"
So I've modified the validation to check for the "expired" word in the message, in case the content of it gets slightly modified in the future