### PR TITLE
[CXP-527] Mint fresh installation token at start of every gRPC call (experiment)

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	cfg "github.com/conductorone/baton-github/pkg/config"
@@ -19,6 +20,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/cli"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
+	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	jwtv5 "github.com/golang-jwt/jwt/v5"
 	"github.com/google/go-github/v69/github"
@@ -107,6 +109,8 @@ type GitHub struct {
 	omitArchivedRepositories bool
 	directCollaboratorsOnly  bool
 	enterprises              []string
+	// installationTokenSource is set in GitHub App mode; nil for PAT.
+	installationTokenSource *forceRefreshTokenSource
 }
 
 func (gh *GitHub) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
@@ -129,6 +133,12 @@ func (gh *GitHub) ResourceSyncers(ctx context.Context) []connectorbuilder.Resour
 
 	if len(gh.enterprises) > 0 {
 		resourceSyncers = append(resourceSyncers, enterpriseRoleBuilder(gh.client, gh.appClient, gh.customClient, gh.enterprises))
+	}
+	if gh.installationTokenSource == nil {
+		return resourceSyncers
+	}
+	for i, s := range resourceSyncers {
+		resourceSyncers[i] = wrapSyncerForRefresh(s, gh.installationTokenSource)
 	}
 	return resourceSyncers
 }
@@ -361,7 +371,7 @@ func newWithGithubApp(ctx context.Context, ghc *cfg.Github) (*GitHub, error) {
 			privateKey: string(ghc.AppPrivatekeyPath),
 		},
 	)
-	ts := oauth2.ReuseTokenSource(
+	ts := newForceRefreshTokenSource(
 		&oauth2.Token{
 			AccessToken: token.GetToken(),
 			Expiry:      token.GetExpiresAt().Time,
@@ -372,6 +382,7 @@ func newWithGithubApp(ctx context.Context, ghc *cfg.Github) (*GitHub, error) {
 			installationID: installation.GetID(),
 			jwtTokenSource: jwtts,
 		},
+		ctxzap.Extract(ctx),
 	)
 	// override the appClient with the reuseTokenSource.
 	appClient, err = newGitHubClient(ctx,
@@ -403,6 +414,7 @@ func newWithGithubApp(ctx context.Context, ghc *cfg.Github) (*GitHub, error) {
 		syncSecrets:              ghc.SyncSecrets,
 		omitArchivedRepositories: ghc.OmitArchivedRepositories,
 		directCollaboratorsOnly:  ghc.DirectCollaboratorsOnly,
+		installationTokenSource:  ts,
 	}
 	return gh, nil
 }
@@ -546,6 +558,176 @@ func (r *appTokenRefresher) Token() (*oauth2.Token, error) {
 		AccessToken: token.GetToken(),
 		Expiry:      token.GetExpiresAt().Time,
 	}, nil
+}
+
+// forceRefreshTokenSource caches a token like oauth2.ReuseTokenSource but
+// exposes ForceRefreshNext so callers can require the next Token() call to
+// refresh, bypassing the expiry check.
+type forceRefreshTokenSource struct {
+	mu        sync.Mutex
+	cur       *oauth2.Token
+	refresh   oauth2.TokenSource
+	forceNext bool
+	logger    *zap.Logger
+}
+
+func newForceRefreshTokenSource(initial *oauth2.Token, refresh oauth2.TokenSource, logger *zap.Logger) *forceRefreshTokenSource {
+	return &forceRefreshTokenSource{cur: initial, refresh: refresh, logger: logger}
+}
+
+func (f *forceRefreshTokenSource) Token() (*oauth2.Token, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if !f.forceNext && f.cur.Valid() {
+		return f.cur, nil
+	}
+	t, err := f.refresh.Token()
+	if err != nil {
+		return nil, err
+	}
+	f.cur = t
+	f.forceNext = false
+	if f.logger != nil {
+		f.logger.Debug("github-connector: minted fresh installation token (per-grpc refresh)")
+	}
+	return t, nil
+}
+
+func (f *forceRefreshTokenSource) ForceRefreshNext() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.forceNext = true
+}
+
+// Refresh-on-entry syncer wrappers. Each wrapper variant covers a distinct
+// combination of optional ResourceSyncer interfaces present on the github
+// connector's syncers, so runtime type assertions in baton-sdk still detect
+// capabilities correctly after wrapping.
+//
+// If new syncers add other optional-interface combinations (e.g.
+// ResourceCreator, AccountManagerLimited without a Deleter, CredentialManager),
+// add a corresponding variant and wire it into wrapSyncerForRefresh.
+
+type rsBase struct {
+	inner connectorbuilder.ResourceSyncerV2
+	src   *forceRefreshTokenSource
+}
+
+func (r *rsBase) ResourceType(ctx context.Context) *v2.ResourceType {
+	r.src.ForceRefreshNext()
+	return r.inner.ResourceType(ctx)
+}
+
+func (r *rsBase) List(ctx context.Context, parentResourceID *v2.ResourceId, opts resourceSdk.SyncOpAttrs) ([]*v2.Resource, *resourceSdk.SyncOpResults, error) {
+	r.src.ForceRefreshNext()
+	return r.inner.List(ctx, parentResourceID, opts)
+}
+
+func (r *rsBase) Entitlements(ctx context.Context, resource *v2.Resource, opts resourceSdk.SyncOpAttrs) ([]*v2.Entitlement, *resourceSdk.SyncOpResults, error) {
+	r.src.ForceRefreshNext()
+	return r.inner.Entitlements(ctx, resource, opts)
+}
+
+func (r *rsBase) Grants(ctx context.Context, resource *v2.Resource, opts resourceSdk.SyncOpAttrs) ([]*v2.Grant, *resourceSdk.SyncOpResults, error) {
+	r.src.ForceRefreshNext()
+	return r.inner.Grants(ctx, resource, opts)
+}
+
+type rsStaticEnt struct {
+	rsBase
+	se connectorbuilder.StaticEntitlementSyncerV2
+}
+
+func (r *rsStaticEnt) StaticEntitlements(ctx context.Context, opts resourceSdk.SyncOpAttrs) ([]*v2.Entitlement, *resourceSdk.SyncOpResults, error) {
+	r.src.ForceRefreshNext()
+	return r.se.StaticEntitlements(ctx, opts)
+}
+
+type rsProvisioning struct {
+	rsBase
+	prov connectorbuilder.ResourceProvisionerLimited
+}
+
+func (r *rsProvisioning) Grant(ctx context.Context, resource *v2.Resource, ent *v2.Entitlement) (annotations.Annotations, error) {
+	r.src.ForceRefreshNext()
+	return r.prov.Grant(ctx, resource, ent)
+}
+
+func (r *rsProvisioning) Revoke(ctx context.Context, grant *v2.Grant) (annotations.Annotations, error) {
+	r.src.ForceRefreshNext()
+	return r.prov.Revoke(ctx, grant)
+}
+
+type rsProvisioningStaticEnt struct {
+	rsProvisioning
+	se connectorbuilder.StaticEntitlementSyncerV2
+}
+
+func (r *rsProvisioningStaticEnt) StaticEntitlements(ctx context.Context, opts resourceSdk.SyncOpAttrs) ([]*v2.Entitlement, *resourceSdk.SyncOpResults, error) {
+	r.src.ForceRefreshNext()
+	return r.se.StaticEntitlements(ctx, opts)
+}
+
+type rsDeleter struct {
+	rsBase
+	del connectorbuilder.ResourceDeleterLimited
+}
+
+func (r *rsDeleter) Delete(ctx context.Context, resourceId *v2.ResourceId) (annotations.Annotations, error) {
+	r.src.ForceRefreshNext()
+	return r.del.Delete(ctx, resourceId)
+}
+
+type rsDeleterAccountMgr struct {
+	rsDeleter
+	acct connectorbuilder.AccountManagerLimited
+}
+
+func (r *rsDeleterAccountMgr) CreateAccount(
+	ctx context.Context,
+	info *v2.AccountInfo,
+	opts *v2.LocalCredentialOptions,
+) (connectorbuilder.CreateAccountResponse, []*v2.PlaintextData, annotations.Annotations, error) {
+	r.src.ForceRefreshNext()
+	return r.acct.CreateAccount(ctx, info, opts)
+}
+
+func (r *rsDeleterAccountMgr) CreateAccountCapabilityDetails(ctx context.Context) (*v2.CredentialDetailsAccountProvisioning, annotations.Annotations, error) {
+	r.src.ForceRefreshNext()
+	return r.acct.CreateAccountCapabilityDetails(ctx)
+}
+
+// wrapSyncerForRefresh picks the smallest wrapper variant whose method set
+// matches the optional interfaces actually present on inner. The variants
+// cover the combinations used by this connector today; see the comment on
+// rsBase for what to do when adding a new one.
+func wrapSyncerForRefresh(inner connectorbuilder.ResourceSyncerV2, src *forceRefreshTokenSource) connectorbuilder.ResourceSyncerV2 {
+	base := rsBase{inner: inner, src: src}
+	prov, isProv := inner.(connectorbuilder.ResourceProvisionerLimited)
+	se, isStaticEnt := inner.(connectorbuilder.StaticEntitlementSyncerV2)
+	del, isDel := inner.(connectorbuilder.ResourceDeleterLimited)
+	acct, isAcct := inner.(connectorbuilder.AccountManagerLimited)
+
+	switch {
+	case isProv && isStaticEnt:
+		return &rsProvisioningStaticEnt{
+			rsProvisioning: rsProvisioning{rsBase: base, prov: prov},
+			se:             se,
+		}
+	case isProv:
+		return &rsProvisioning{rsBase: base, prov: prov}
+	case isStaticEnt:
+		return &rsStaticEnt{rsBase: base, se: se}
+	case isDel && isAcct:
+		return &rsDeleterAccountMgr{
+			rsDeleter: rsDeleter{rsBase: base, del: del},
+			acct:      acct,
+		}
+	case isDel:
+		return &rsDeleter{rsBase: base, del: del}
+	default:
+		return &base
+	}
 }
 
 func getOrgs(ctx context.Context, client *github.Client, orgs []string) ([]string, error) {

--- a/pkg/connector/connector_test.go
+++ b/pkg/connector/connector_test.go
@@ -1,0 +1,236 @@
+package connector
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
+	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+)
+
+// stubRefresher returns a successively-numbered token on each call.
+type stubRefresher struct {
+	mu    sync.Mutex
+	calls int32
+}
+
+func (s *stubRefresher) Token() (*oauth2.Token, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := atomic.AddInt32(&s.calls, 1)
+	return &oauth2.Token{
+		AccessToken: "minted-" + itoa(n),
+		Expiry:      time.Now().Add(time.Hour),
+	}, nil
+}
+
+func itoa(n int32) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [16]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}
+
+func TestForceRefreshTokenSource_ReusesValidToken(t *testing.T) {
+	ref := &stubRefresher{}
+	src := newForceRefreshTokenSource(
+		&oauth2.Token{AccessToken: "initial", Expiry: time.Now().Add(time.Hour)},
+		ref,
+		zap.NewNop(),
+	)
+
+	for range 3 {
+		tok, err := src.Token()
+		require.NoError(t, err)
+		require.Equal(t, "initial", tok.AccessToken)
+	}
+	require.Equal(t, int32(0), atomic.LoadInt32(&ref.calls))
+}
+
+func TestForceRefreshTokenSource_RefreshesWhenExpired(t *testing.T) {
+	ref := &stubRefresher{}
+	src := newForceRefreshTokenSource(
+		&oauth2.Token{AccessToken: "initial", Expiry: time.Now().Add(-time.Minute)},
+		ref,
+		zap.NewNop(),
+	)
+
+	tok, err := src.Token()
+	require.NoError(t, err)
+	require.Equal(t, "minted-1", tok.AccessToken)
+	require.Equal(t, int32(1), atomic.LoadInt32(&ref.calls))
+}
+
+func TestForceRefreshTokenSource_ForceRefreshNextBypassesValidCache(t *testing.T) {
+	ref := &stubRefresher{}
+	src := newForceRefreshTokenSource(
+		&oauth2.Token{AccessToken: "initial", Expiry: time.Now().Add(time.Hour)},
+		ref,
+		zap.NewNop(),
+	)
+
+	src.ForceRefreshNext()
+	tok, err := src.Token()
+	require.NoError(t, err)
+	require.Equal(t, "minted-1", tok.AccessToken)
+	require.Equal(t, int32(1), atomic.LoadInt32(&ref.calls))
+
+	// Flag must clear after a forced refresh; subsequent calls reuse cache.
+	tok, err = src.Token()
+	require.NoError(t, err)
+	require.Equal(t, "minted-1", tok.AccessToken)
+	require.Equal(t, int32(1), atomic.LoadInt32(&ref.calls), "no second refresh expected")
+}
+
+func TestForceRefreshTokenSource_RefresherErrorPropagates(t *testing.T) {
+	src := newForceRefreshTokenSource(
+		&oauth2.Token{AccessToken: "initial", Expiry: time.Now().Add(-time.Minute)},
+		oauth2.TokenSource(stubErrSource{}),
+		zap.NewNop(),
+	)
+	_, err := src.Token()
+	require.ErrorContains(t, err, "boom")
+}
+
+type stubErrSource struct{}
+
+func (stubErrSource) Token() (*oauth2.Token, error) { return nil, errors.New("boom") }
+
+// --- wrapSyncerForRefresh -----------------------------------------------------
+
+func newTestSrc() *forceRefreshTokenSource {
+	return newForceRefreshTokenSource(
+		&oauth2.Token{AccessToken: "tok", Expiry: time.Now().Add(time.Hour)},
+		&stubRefresher{},
+		zap.NewNop(),
+	)
+}
+
+// fakeBaseSyncer implements only ResourceSyncerV2.
+type fakeBaseSyncer struct {
+	listCalls int32
+}
+
+func (f *fakeBaseSyncer) ResourceType(context.Context) *v2.ResourceType {
+	return &v2.ResourceType{Id: "fake"}
+}
+func (f *fakeBaseSyncer) List(_ context.Context, _ *v2.ResourceId, _ resourceSdk.SyncOpAttrs) ([]*v2.Resource, *resourceSdk.SyncOpResults, error) {
+	atomic.AddInt32(&f.listCalls, 1)
+	return nil, nil, nil
+}
+func (f *fakeBaseSyncer) Entitlements(_ context.Context, _ *v2.Resource, _ resourceSdk.SyncOpAttrs) ([]*v2.Entitlement, *resourceSdk.SyncOpResults, error) {
+	return nil, nil, nil
+}
+func (f *fakeBaseSyncer) Grants(_ context.Context, _ *v2.Resource, _ resourceSdk.SyncOpAttrs) ([]*v2.Grant, *resourceSdk.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+// fakeProvisioningSyncer adds Grant/Revoke (V1 ResourceProvisionerLimited).
+type fakeProvisioningSyncer struct {
+	fakeBaseSyncer
+}
+
+func (f *fakeProvisioningSyncer) Grant(context.Context, *v2.Resource, *v2.Entitlement) (annotations.Annotations, error) {
+	return nil, nil
+}
+func (f *fakeProvisioningSyncer) Revoke(context.Context, *v2.Grant) (annotations.Annotations, error) {
+	return nil, nil
+}
+
+// fakeProvisioningStaticEntSyncer adds StaticEntitlements on top.
+type fakeProvisioningStaticEntSyncer struct {
+	fakeProvisioningSyncer
+}
+
+func (f *fakeProvisioningStaticEntSyncer) StaticEntitlements(context.Context, resourceSdk.SyncOpAttrs) ([]*v2.Entitlement, *resourceSdk.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+// fakeDeleterSyncer adds Delete.
+type fakeDeleterSyncer struct {
+	fakeBaseSyncer
+}
+
+func (f *fakeDeleterSyncer) Delete(context.Context, *v2.ResourceId) (annotations.Annotations, error) {
+	return nil, nil
+}
+
+// fakeDeleterAccountMgrSyncer adds CreateAccount + capability details.
+type fakeDeleterAccountMgrSyncer struct {
+	fakeDeleterSyncer
+}
+
+func (f *fakeDeleterAccountMgrSyncer) CreateAccount(
+	context.Context,
+	*v2.AccountInfo,
+	*v2.LocalCredentialOptions,
+) (connectorbuilder.CreateAccountResponse, []*v2.PlaintextData, annotations.Annotations, error) {
+	return nil, nil, nil, nil
+}
+func (f *fakeDeleterAccountMgrSyncer) CreateAccountCapabilityDetails(context.Context) (*v2.CredentialDetailsAccountProvisioning, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+
+func TestWrapSyncerForRefresh_PreservesCapabilities(t *testing.T) {
+	src := newTestSrc()
+	cases := []struct {
+		name       string
+		inner      connectorbuilder.ResourceSyncerV2
+		wantProv   bool
+		wantStatic bool
+		wantDel    bool
+		wantAcct   bool
+	}{
+		{name: "base", inner: &fakeBaseSyncer{}},
+		{name: "provisioning_static_ent", inner: &fakeProvisioningStaticEntSyncer{}, wantProv: true, wantStatic: true},
+		{name: "deleter", inner: &fakeDeleterSyncer{}, wantDel: true},
+		{name: "deleter_account_mgr", inner: &fakeDeleterAccountMgrSyncer{}, wantDel: true, wantAcct: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wrapped := wrapSyncerForRefresh(tc.inner, src)
+			_, isProv := wrapped.(connectorbuilder.ResourceProvisionerLimited)
+			_, isStatic := wrapped.(connectorbuilder.StaticEntitlementSyncerV2)
+			_, isDel := wrapped.(connectorbuilder.ResourceDeleterLimited)
+			_, isAcct := wrapped.(connectorbuilder.AccountManagerLimited)
+			require.Equal(t, tc.wantProv, isProv, "ResourceProvisionerLimited")
+			require.Equal(t, tc.wantStatic, isStatic, "StaticEntitlementSyncerV2")
+			require.Equal(t, tc.wantDel, isDel, "ResourceDeleterLimited")
+			require.Equal(t, tc.wantAcct, isAcct, "AccountManagerLimited")
+		})
+	}
+}
+
+func TestWrapSyncerForRefresh_ListForcesRefresh(t *testing.T) {
+	src := newTestSrc()
+	inner := &fakeBaseSyncer{}
+	wrapped := wrapSyncerForRefresh(inner, src)
+
+	// Sanity: cached token initially.
+	tok, _ := src.Token()
+	require.Equal(t, "tok", tok.AccessToken)
+
+	_, _, err := wrapped.List(context.Background(), nil, resourceSdk.SyncOpAttrs{})
+	require.NoError(t, err)
+	require.Equal(t, int32(1), atomic.LoadInt32(&inner.listCalls))
+
+	// After List, the next Token() call should refresh because ForceRefreshNext fired.
+	tok, _ = src.Token()
+	require.NotEqual(t, "tok", tok.AccessToken, "expected a fresh token after List")
+}


### PR DESCRIPTION
## Summary

Experiment branch testing btipling's suggestion from #151: mint a fresh GitHub App installation token at the start of every gRPC method on the connector, instead of relying on `oauth2.ReuseTokenSource`. Branched off `main`, not stacked on #151 or #152, so it can be tested in isolation.

## Hypothesis

PR #152 (cap cached token lifetime at `stated_expiry - 10m`) deployed as `v0.3.2-test.1` and did **not** stop the 401s — three more in the 3 hours after deploy on fanduel. That weakens the clock-skew / cache-aging story and suggests either (a) the existing oauth2 refresh path is broken in a way we can't see, or (b) tokens are being invalidated externally. This PR bypasses `oauth2.ReuseTokenSource` entirely so we can tell which.

If 401s drop with this change, the existing refresh path has a bug we should fix. If they don't, the cause is external and PR #151's reactive retry is the right answer.

## What changed

`pkg/connector/connector.go`:
- New `forceRefreshTokenSource` — caches a token like `oauth2.ReuseTokenSource` but exposes `ForceRefreshNext()` to make the next `Token()` call refresh regardless of expiry.
- `newWithGithubApp` uses it for the installation token; stored on the `GitHub` struct as `installationTokenSource`.
- `ResourceSyncers()` wraps each syncer with `wrapSyncerForRefresh`, which forces a refresh on every method entry.
- Wrapper variants cover the optional-interface combinations actually present on this connector (Provisioner, Provisioner+StaticEnt, Deleter, Deleter+AccountManager, StaticEnt, plain) so capability detection via type assertion still works.

PAT mode is unaffected — `installationTokenSource` is nil and `ResourceSyncers()` skips wrapping.

A DEBUG log line fires when a fresh token is actually minted:
```
github-connector: minted fresh installation token (per-grpc refresh)
```

## Cost

~200ms per gRPC call. For a multi-day fanduel sync that's roughly 16–30 min of cumulative latency. Acceptable for an experiment. JWT-authenticated endpoints on GitHub Apps are limited to 30/min per app — well above per-Lambda-instance rate, but worth watching during the test.

## Test plan

- [x] `go test -race ./pkg/connector/`
- [x] `make lint`
- [ ] Build a test release off this branch.
- [ ] Point fanduel's connector at it.
- [ ] Watch for 24h. Confirm via Datadog: mint-log rate roughly tracks gRPC call rate; 401 sync-failure rate compared against baseline.

If 401s persist after this, the cause is external and we should land #151. If they stop, we have a bug to chase in the existing refresh path.