### PR TITLE
[CXP-527] Sleep 3s after minting installation token (experiment)

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -35,6 +35,13 @@ const githubDotCom = "https://github.com"
 // JWT token expires in 10 minutes, so we set it to 9 minutes to leave some buffer.
 const jwtExpiryTime = 9 * time.Minute
 
+// installationTokenPropagationDelay pauses briefly after minting a GitHub App
+// installation token so it has time to propagate across GitHub's API tier.
+// GitHub staff have noted that freshly minted tokens may be rejected as invalid
+// by API servers for ~1-3s after issuance.
+// https://github.com/orgs/community/discussions/162975#discussioncomment-13603594
+const installationTokenPropagationDelay = 3 * time.Second
+
 var (
 	ValidAssetDomains     = []string{"avatars.githubusercontent.com"}
 	maxPageSize       int = 100 // maximum page size github supported.
@@ -499,6 +506,15 @@ func getInstallationToken(ctx context.Context, c *github.Client, id int64) (*git
 			zap.String("response_body", string(body)),
 		)
 		return nil, fmt.Errorf("github-connector: unexpected status %d creating installation token for installation %d: %s", resp.StatusCode, id, body)
+	}
+
+	l.Debug("github-connector: sleeping after installation token mint to allow propagation",
+		zap.Duration("delay", installationTokenPropagationDelay),
+	)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(installationTokenPropagationDelay):
 	}
 
 	return token, nil


### PR DESCRIPTION
## Summary

Sleeps for 3 seconds after a successful GitHub App installation-token mint inside `pkg/connector/connector.go#getInstallationToken` before returning the token to callers. The sleep is `select`-guarded against `ctx.Done()` so it doesn't outlive a cancelled context. Both mint sites (`newWithGithubApp` and `appTokenRefresher.Token`) inherit the behavior since both go through `getInstallationToken`.

This is an isolated experiment, not a fix-in-place. No retry, no cache-lifetime change, no per-call mint.

## Hypothesis

GitHub's token-issuance servers and API servers are separate tiers. Freshly minted installation tokens take ~1-3 seconds to propagate across the API tier; calls that hit an API server before propagation completes return 401. GitHub staff acknowledge this in a community thread:

https://github.com/orgs/community/discussions/162975#discussioncomment-13603594

The customer-side data fits this shape — a 401 was observed ~3 minutes into a fresh activity on a recently-minted token, well inside the token's stated TTL.

## Why this stands alone

This PR is intentionally independent of the other in-flight CXP-527 work:

- **#151** (reactive: retry once on 401 with cache invalidation) — orthogonal. If propagation is the cause, #151 will work better with this sleep baked in.
- **#152** (proactive: cap cached token lifetime at `stated_expiry - 10m`, deployed as `v0.3.2-test.1`) — did not move the needle. Consistent with the propagation hypothesis: refreshing earlier just produces more newly-minted tokens, which are precisely the ones that race.
- **#155** (per-gRPC-call mint) — predicted to make things *worse* under this hypothesis, since every call would be on a freshly-minted token. Not deploying.

Do not stack this on any of the above. Branch is cut from `origin/main`.

## Cost

~3s per `CreateInstallationToken` call. Mints happen on Lambda cold-start and on rare cache-expiry. With parallel sync = 4, that's roughly 4 mints at activity start ≈ 12s added latency per activity. Acceptable for an experiment.

## Test plan

- [ ] Cut a test release from this branch.
- [ ] Confirm `release_version` shows up correctly in Datadog for the test deployment.
- [ ] Look for the new DEBUG log line (`github-connector: sleeping after installation token mint to allow propagation`) to confirm the sleep is firing in production.
- [ ] Watch the `Failed to sync connector, last step error` rate for the affected customer over 24h, against a baseline of 3 failures in 3h on `v0.3.2-test.1`.

## Decision rule

- **401s drop materially** → propagation race confirmed. Close this PR and land #151 with the 3s sleep folded into the success path of `getInstallationToken`.
- **401s do not drop** → propagation race is not the cause. Close this PR; #151's retry-on-401 stands on its own merits and is the right answer.