### PR TITLE
fix(connector): retry /collaborators on HTTP/2 transient errors (OPS-1676)

### DIFF
--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -309,6 +310,33 @@ func isTemporarilyUnavailable(resp *github.Response) bool {
 	return resp.StatusCode == http.StatusServiceUnavailable ||
 		resp.StatusCode == http.StatusBadGateway ||
 		resp.StatusCode == http.StatusGatewayTimeout
+}
+
+// isRetryableHTTP2Error reports whether err is an HTTP/2 client-side transient
+// failure that warrants a per-call retry. These surface when GitHub stalls on a
+// large paginated response (response-header timeout) or gracefully shuts down a
+// stream mid-request (GOAWAY without GetBody). See inc-814 for context.
+func isRetryableHTTP2Error(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Context cancellation/expiry of the parent caller is never retryable —
+	// the retry would just hit the same dead deadline.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "http2: timeout awaiting response headers") {
+		return true
+	}
+	if strings.Contains(msg, "http2: Transport received Server's graceful shutdown GOAWAY") {
+		return true
+	}
+	var nerr net.Error
+	if errors.As(err, &nerr) && nerr.Timeout() {
+		return true
+	}
+	return false
 }
 
 // gitHubErrorMessage extracts a human-readable error message from a GitHub API error.

--- a/pkg/connector/repository.go
+++ b/pkg/connector/repository.go
@@ -2,6 +2,7 @@ package connector
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand/v2"
 	"net/http"
@@ -548,13 +549,17 @@ var listCollaboratorsBackoffs = []time.Duration{
 	3 * time.Second,
 }
 
+// sleepFn is the indirection used by listCollaboratorsWithRetry to wait between
+// retries. Tests replace it with an immediate-fire channel to avoid real wall
+// time. Reassignment is not safe under t.Parallel.
+var sleepFn = time.After
+
 func listCollaboratorsWithRetry(
 	ctx context.Context,
 	client *github.Client,
 	org, repo string,
 	opts *github.ListCollaboratorsOptions,
 ) ([]*github.User, *github.Response, error) {
-	l := ctxzap.Extract(ctx)
 	var (
 		users []*github.User
 		resp  *github.Response
@@ -570,7 +575,7 @@ func listCollaboratorsWithRetry(
 		}
 		base := listCollaboratorsBackoffs[attempt]
 		jitter := time.Duration(rand.Int64N(int64(base/2))) - base/4
-		l.Debug("retrying ListCollaborators after transient HTTP/2 error",
+		ctxzap.Extract(ctx).Debug("retrying ListCollaborators after transient HTTP/2 error",
 			zap.String("org", org),
 			zap.String("repo", repo),
 			zap.Int("attempt", attempt+1),
@@ -579,8 +584,10 @@ func listCollaboratorsWithRetry(
 		)
 		select {
 		case <-ctx.Done():
-			return users, resp, err
-		case <-time.After(base + jitter):
+			// Surface cancellation as the primary signal but preserve the
+			// transient error for log attribution.
+			return nil, nil, errors.Join(ctx.Err(), err)
+		case <-sleepFn(base + jitter):
 		}
 	}
 	return users, resp, err

--- a/pkg/connector/repository.go
+++ b/pkg/connector/repository.go
@@ -574,6 +574,7 @@ func listCollaboratorsWithRetry(
 			break
 		}
 		base := listCollaboratorsBackoffs[attempt]
+		//nolint:gosec // G404: math/rand/v2 is appropriate here; jitter is non-security-sensitive.
 		jitter := time.Duration(rand.Int64N(int64(base/2))) - base/4
 		ctxzap.Extract(ctx).Debug("retrying ListCollaborators after transient HTTP/2 error",
 			zap.String("org", org),

--- a/pkg/connector/repository.go
+++ b/pkg/connector/repository.go
@@ -3,9 +3,11 @@ package connector
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -220,7 +222,7 @@ func (o *repositoryResourceType) Grants(
 				PerPage: maxPageSize,
 			},
 		}
-		users, resp, err := o.client.Repositories.ListCollaborators(ctx, orgName, resource.DisplayName, listOpts)
+		users, resp, err := listCollaboratorsWithRetry(ctx, o.client, orgName, resource.DisplayName, listOpts)
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusForbidden {
 				l.Debug("insufficient access to list collaborators, skipping",
@@ -533,6 +535,55 @@ func repositoryBuilder(client *github.Client, orgCache *orgNameCache, omitArchiv
 		omitArchivedRepositories: omitArchivedRepositories,
 		directCollaboratorsOnly:  directCollaboratorsOnly,
 	}
+}
+
+// listCollaboratorsBackoffs is the per-attempt base delay before retrying a
+// transient HTTP/2 failure on /repos/{org}/{repo}/collaborators. Three attempts
+// total; jitter of ±25% is added at call time. See inc-814: GitHub stalls on
+// large paginated collaborator responses produce response-header timeouts that
+// previously aborted the entire GRANT_EXPANSION activity for a repo.
+var listCollaboratorsBackoffs = []time.Duration{
+	250 * time.Millisecond,
+	1 * time.Second,
+	3 * time.Second,
+}
+
+func listCollaboratorsWithRetry(
+	ctx context.Context,
+	client *github.Client,
+	org, repo string,
+	opts *github.ListCollaboratorsOptions,
+) ([]*github.User, *github.Response, error) {
+	l := ctxzap.Extract(ctx)
+	var (
+		users []*github.User
+		resp  *github.Response
+		err   error
+	)
+	for attempt := 0; attempt < len(listCollaboratorsBackoffs); attempt++ {
+		users, resp, err = client.Repositories.ListCollaborators(ctx, org, repo, opts)
+		if err == nil || !isRetryableHTTP2Error(err) {
+			return users, resp, err
+		}
+		if attempt == len(listCollaboratorsBackoffs)-1 {
+			break
+		}
+		base := listCollaboratorsBackoffs[attempt]
+		jitter := time.Duration(rand.Int64N(int64(base/2))) - base/4
+		l.Debug("retrying ListCollaborators after transient HTTP/2 error",
+			zap.String("org", org),
+			zap.String("repo", repo),
+			zap.Int("attempt", attempt+1),
+			zap.Duration("backoff", base+jitter),
+			zap.Error(err),
+		)
+		select {
+		case <-ctx.Done():
+			return users, resp, err
+		case <-time.After(base + jitter):
+		}
+	}
+	return users, resp, err
 }
 
 func skipGrantsForResourceType(bag *pagination.Bag) (string, error) {

--- a/pkg/connector/retry_test.go
+++ b/pkg/connector/retry_test.go
@@ -95,9 +95,15 @@ type scriptedRT struct {
 	steps []scriptedStep
 }
 
+// scriptedStep describes one round-trip outcome. When err != nil it is
+// returned as the transport error; otherwise the RT constructs a response
+// from statusCode and body. We hold raw fields instead of a pre-constructed
+// *http.Response so the response body lifetime is owned by the RoundTrip
+// call, which keeps the bodyclose linter happy.
 type scriptedStep struct {
-	err  error          // if non-nil, returned as the RoundTrip error
-	resp *http.Response // otherwise this response is returned
+	err        error
+	statusCode int
+	body       string
 }
 
 func (r *scriptedRT) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -109,22 +115,18 @@ func (r *scriptedRT) RoundTrip(req *http.Request) (*http.Response, error) {
 	if step.err != nil {
 		return nil, step.err
 	}
-	return step.resp, nil
+	return &http.Response{
+		StatusCode: step.statusCode,
+		Body:       io.NopCloser(strings.NewReader(step.body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
 }
 
 func (r *scriptedRT) callCount() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.calls
-}
-
-func okEmptyResponse(req *http.Request) *http.Response {
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(strings.NewReader(`[]`)),
-		Header:     make(http.Header),
-		Request:    req,
-	}
 }
 
 // installImmediateSleep swaps sleepFn so retry backoffs don't burn wall time.
@@ -148,7 +150,7 @@ func newScriptedClient(t *testing.T, steps ...scriptedStep) (*github.Client, *sc
 
 func TestListCollaboratorsWithRetry_SuccessFirstAttempt(t *testing.T) {
 	installImmediateSleep(t)
-	client, rt := newScriptedClient(t, scriptedStep{resp: okEmptyResponse(&http.Request{})})
+	client, rt := newScriptedClient(t, scriptedStep{statusCode: http.StatusOK, body: `[]`})
 
 	_, _, err := listCollaboratorsWithRetry(t.Context(), client, "org", "repo", &github.ListCollaboratorsOptions{})
 	require.NoError(t, err)
@@ -159,7 +161,7 @@ func TestListCollaboratorsWithRetry_RetriesThenSucceeds(t *testing.T) {
 	installImmediateSleep(t)
 	client, rt := newScriptedClient(t,
 		scriptedStep{err: errors.New(hdrTimeoutMsg)},
-		scriptedStep{resp: okEmptyResponse(&http.Request{})},
+		scriptedStep{statusCode: http.StatusOK, body: `[]`},
 	)
 
 	_, _, err := listCollaboratorsWithRetry(t.Context(), client, "org", "repo", &github.ListCollaboratorsOptions{})

--- a/pkg/connector/retry_test.go
+++ b/pkg/connector/retry_test.go
@@ -1,0 +1,50 @@
+package connector
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type fakeTimeoutErr struct{}
+
+func (fakeTimeoutErr) Error() string   { return "i/o timeout" }
+func (fakeTimeoutErr) Timeout() bool   { return true }
+func (fakeTimeoutErr) Temporary() bool { return true }
+
+func TestIsRetryableHTTP2Error(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unrelated", errors.New("boom"), false},
+		{"response-header timeout", errors.New("http2: timeout awaiting response headers"), true},
+		{"goaway no GetBody", errors.New("http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error"), true},
+		{"net.Error timeout", fakeTimeoutErr{}, true},
+		{"context deadline exceeded (not wrapped as net.Error)", context.DeadlineExceeded, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := isRetryableHTTP2Error(c.err)
+			if got != c.want {
+				t.Fatalf("isRetryableHTTP2Error(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+func TestListCollaboratorsBackoffsShape(t *testing.T) {
+	if len(listCollaboratorsBackoffs) != 3 {
+		t.Fatalf("expected 3 backoff slots, got %d", len(listCollaboratorsBackoffs))
+	}
+	prev := time.Duration(0)
+	for i, d := range listCollaboratorsBackoffs {
+		if d <= prev {
+			t.Fatalf("backoff[%d]=%s is not strictly increasing from %s", i, d, prev)
+		}
+		prev = d
+	}
+}

--- a/pkg/connector/retry_test.go
+++ b/pkg/connector/retry_test.go
@@ -3,15 +3,31 @@ package connector
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/google/go-github/v69/github"
+	"github.com/stretchr/testify/require"
 )
 
 type fakeTimeoutErr struct{}
 
-func (fakeTimeoutErr) Error() string   { return "i/o timeout" }
-func (fakeTimeoutErr) Timeout() bool   { return true }
-func (fakeTimeoutErr) Temporary() bool { return true }
+func (fakeTimeoutErr) Error() string { return "i/o timeout" }
+func (fakeTimeoutErr) Timeout() bool { return true }
+
+// Temporary satisfies net.Error; deprecated and unused by isRetryableHTTP2Error.
+func (fakeTimeoutErr) Temporary() bool { return false }
+
+const (
+	hdrTimeoutMsg = "http2: timeout awaiting response headers"
+	goawayInner   = "http2: Transport received Server's graceful shutdown GOAWAY"
+	goawayWrapped = "http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error"
+)
 
 func TestIsRetryableHTTP2Error(t *testing.T) {
 	cases := []struct {
@@ -21,30 +37,199 @@ func TestIsRetryableHTTP2Error(t *testing.T) {
 	}{
 		{"nil", nil, false},
 		{"unrelated", errors.New("boom"), false},
-		{"response-header timeout", errors.New("http2: timeout awaiting response headers"), true},
-		{"goaway no GetBody", errors.New("http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error"), true},
+
+		// Positive: bare error strings from x/net/http2.
+		{"response-header timeout", errors.New(hdrTimeoutMsg), true},
+		{"goaway raw inner string", errors.New(goawayInner), true},
+		{"goaway wrapped no-GetBody", errors.New(goawayWrapped), true},
+
+		// Positive: net.Error.Timeout().
 		{"net.Error timeout", fakeTimeoutErr{}, true},
-		{"context deadline exceeded (not wrapped as net.Error)", context.DeadlineExceeded, false},
+
+		// Positive: errors wrapped via %w — the substring check still matches
+		// because err.Error() walks the wrap chain.
+		{"wrapped response-header timeout", fmt.Errorf("ListCollaborators: %w", errors.New(hdrTimeoutMsg)), true},
+		{"wrapped net.Error timeout", fmt.Errorf("dial: %w", fakeTimeoutErr{}), true},
+
+		// Negative: context errors must short-circuit before the net.Error
+		// check (context.DeadlineExceeded satisfies net.Error.Timeout()=true).
+		{"context.DeadlineExceeded short-circuited", context.DeadlineExceeded, false},
+		{"context.Canceled short-circuited", context.Canceled, false},
+		{"wrapped context.Canceled", fmt.Errorf("op cancelled: %w", context.Canceled), false},
+
+		// Negative: near-miss substrings that must not over-retry.
+		{"truncated hdr-timeout substring", errors.New("http2: timeout"), false},
+		{"generic http2 stream error", errors.New("http2: stream error"), false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := isRetryableHTTP2Error(c.err)
-			if got != c.want {
-				t.Fatalf("isRetryableHTTP2Error(%v) = %v, want %v", c.err, got, c.want)
-			}
+			require.Equal(t, c.want, isRetryableHTTP2Error(c.err),
+				"isRetryableHTTP2Error(%v) classification", c.err)
 		})
 	}
 }
 
-func TestListCollaboratorsBackoffsShape(t *testing.T) {
-	if len(listCollaboratorsBackoffs) != 3 {
-		t.Fatalf("expected 3 backoff slots, got %d", len(listCollaboratorsBackoffs))
-	}
+// TestListCollaboratorsBackoffsBudget enforces both the 3-attempt invariant
+// and a total-budget ceiling so a future tuning regression that, e.g., bumps
+// the last slot to 30s will fail loudly here.
+func TestListCollaboratorsBackoffsBudget(t *testing.T) {
+	require.Len(t, listCollaboratorsBackoffs, 3, "three-attempt invariant")
+	require.Less(t, listCollaboratorsBackoffs[0], time.Second, "first delay must be sub-second")
+
+	var total time.Duration
 	prev := time.Duration(0)
 	for i, d := range listCollaboratorsBackoffs {
-		if d <= prev {
-			t.Fatalf("backoff[%d]=%s is not strictly increasing from %s", i, d, prev)
-		}
+		require.Greater(t, d, prev, "backoff[%d] must be strictly increasing", i)
 		prev = d
+		total += d
 	}
+	require.LessOrEqual(t, total, 10*time.Second, "total backoff budget exceeded")
+}
+
+// scriptedRT returns a scripted error or response per RoundTrip call. It panics
+// the test on extra calls so over-retry is caught loudly.
+type scriptedRT struct {
+	mu    sync.Mutex
+	t     *testing.T
+	calls int
+	steps []scriptedStep
+}
+
+type scriptedStep struct {
+	err  error          // if non-nil, returned as the RoundTrip error
+	resp *http.Response // otherwise this response is returned
+}
+
+func (r *scriptedRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	require.Less(r.t, r.calls, len(r.steps), "unexpected extra RoundTrip call (call #%d)", r.calls+1)
+	step := r.steps[r.calls]
+	r.calls++
+	if step.err != nil {
+		return nil, step.err
+	}
+	return step.resp, nil
+}
+
+func (r *scriptedRT) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+func okEmptyResponse(req *http.Request) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`[]`)),
+		Header:     make(http.Header),
+		Request:    req,
+	}
+}
+
+// installImmediateSleep swaps sleepFn so retry backoffs don't burn wall time.
+// Not safe under t.Parallel; callers must avoid it.
+func installImmediateSleep(t *testing.T) {
+	t.Helper()
+	orig := sleepFn
+	sleepFn = func(time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	}
+	t.Cleanup(func() { sleepFn = orig })
+}
+
+func newScriptedClient(t *testing.T, steps ...scriptedStep) (*github.Client, *scriptedRT) {
+	t.Helper()
+	rt := &scriptedRT{t: t, steps: steps}
+	return github.NewClient(&http.Client{Transport: rt}), rt
+}
+
+func TestListCollaboratorsWithRetry_SuccessFirstAttempt(t *testing.T) {
+	installImmediateSleep(t)
+	client, rt := newScriptedClient(t, scriptedStep{resp: okEmptyResponse(&http.Request{})})
+
+	_, _, err := listCollaboratorsWithRetry(t.Context(), client, "org", "repo", &github.ListCollaboratorsOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, rt.callCount(), "no retry on success")
+}
+
+func TestListCollaboratorsWithRetry_RetriesThenSucceeds(t *testing.T) {
+	installImmediateSleep(t)
+	client, rt := newScriptedClient(t,
+		scriptedStep{err: errors.New(hdrTimeoutMsg)},
+		scriptedStep{resp: okEmptyResponse(&http.Request{})},
+	)
+
+	_, _, err := listCollaboratorsWithRetry(t.Context(), client, "org", "repo", &github.ListCollaboratorsOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 2, rt.callCount(), "exactly one retry before success")
+}
+
+func TestListCollaboratorsWithRetry_ExhaustsAllAttempts(t *testing.T) {
+	installImmediateSleep(t)
+	client, rt := newScriptedClient(t,
+		scriptedStep{err: errors.New(hdrTimeoutMsg)},
+		scriptedStep{err: errors.New(hdrTimeoutMsg)},
+		scriptedStep{err: errors.New(goawayWrapped)},
+	)
+
+	_, _, err := listCollaboratorsWithRetry(t.Context(), client, "org", "repo", &github.ListCollaboratorsOptions{})
+	require.Error(t, err)
+	require.Equal(t, 3, rt.callCount(), "exactly three attempts on full failure")
+	require.Contains(t, err.Error(), "GOAWAY", "final attempt's error is surfaced")
+}
+
+func TestListCollaboratorsWithRetry_NonRetryableShortCircuits(t *testing.T) {
+	installImmediateSleep(t)
+	// A non-classified error must abort after the first attempt.
+	client, rt := newScriptedClient(t, scriptedStep{err: errors.New("some random non-retryable error")})
+
+	_, _, err := listCollaboratorsWithRetry(t.Context(), client, "org", "repo", &github.ListCollaboratorsOptions{})
+	require.Error(t, err)
+	require.Equal(t, 1, rt.callCount(), "non-retryable error must not retry")
+}
+
+func TestListCollaboratorsWithRetry_ContextCancelDuringBackoff(t *testing.T) {
+	// Replace sleepFn with one that blocks until we explicitly release it,
+	// so we can cancel the ctx mid-backoff and assert the select branch.
+	orig := sleepFn
+	sleepStarted := make(chan struct{}, len(listCollaboratorsBackoffs))
+	hold := make(chan time.Time) // never sent on
+	sleepFn = func(time.Duration) <-chan time.Time {
+		sleepStarted <- struct{}{}
+		return hold
+	}
+	t.Cleanup(func() { sleepFn = orig })
+
+	client, rt := newScriptedClient(t,
+		scriptedStep{err: errors.New(hdrTimeoutMsg)},
+		// Second step is unreachable because ctx will be cancelled in backoff.
+		scriptedStep{err: errors.New("UNREACHABLE")},
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, err := listCollaboratorsWithRetry(ctx, client, "org", "repo", &github.ListCollaboratorsOptions{})
+		errCh <- err
+	}()
+
+	select {
+	case <-sleepStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("retry never entered backoff")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.Canceled, "ctx.Err() must be the primary signal")
+		require.Contains(t, err.Error(), hdrTimeoutMsg, "underlying transient err preserved in joined error")
+	case <-time.After(2 * time.Second):
+		t.Fatal("listCollaboratorsWithRetry did not return after ctx cancel")
+	}
+	require.Equal(t, 1, rt.callCount(), "must not start the second attempt after ctx cancel")
 }


### PR DESCRIPTION
## Summary

Retry the `GET /repos/{org}/{repo}/collaborators?affiliation=all` call on HTTP/2 transient errors that today abort the whole `GRANT_EXPANSION` activity for a repo.

- 3-attempt backoff (250ms → 1s → 3s, ±25% jitter)
- Classified retry: `http2: timeout awaiting response headers`, `http2: ... GOAWAY ... Request.GetBody`, and `net.Error.Timeout()`
- Explicitly NOT retryable: `context.Canceled`, `context.DeadlineExceeded` — parent ctx is already dead, retry would just hit the same wall
- All other errors (auth, rate-limit, 4xx, 5xx) fall through to existing `wrapGitHubError` path unchanged

Linear: [OPS-1676](https://linear.app/ductone/issue/OPS-1676)
Incident: [inc-814](https://us3.datadoghq.com/incidents/814)

## Why

During inc-814 (DoorDash creditornot sync), per-tenant logs over 34h showed:

| Count | Pattern |
|---:|---|
| 477 | `http2: timeout awaiting response headers` |
| 96  | `http2: Transport: cannot retry err [Server's graceful shutdown GOAWAY] ... define Request.GetBody` |
| 1,038 | `context canceled` (downstream cascade from the above) |

Independent Datadog check confirmed Squid was healthy across the window (30,195 `api.github.com` lines, 100% `TCP_TUNNEL/200`, zero FD/abort warnings) — the proxy is not the cause. The timeouts originate in the Lambda's HTTP/2 client when GitHub stalls on large paginated responses.

## Scope

Isolated to one call site at `pkg/connector/repository.go:223`. No changes to `baton-sdk/pkg/uhttp` transport behavior (fleet-wide retry would be a separate ticket).

## Not in this PR (separate tickets)

- Token refresh on 401 (also surfaced in inc-814)
- Reconsidering `affiliation=all` on `/collaborators`
- `half_closed_clients on` in Squid config

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/connector/... -count=1` (passes; existing tests unaffected)
- [x] `TestIsRetryableHTTP2Error` — table-driven classification including the actual incident error strings + a `net.Error` timeout + an explicit assertion that `context.DeadlineExceeded` is NOT classified retryable
- [x] `TestListCollaboratorsBackoffsShape` — guards the 3-step monotonic-increasing backoff invariant
- [ ] Manual smoke: against a connector instance, inject a transport that returns `http2: timeout awaiting response headers` for the first two calls then success — verify retry observed in logs, sync proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)