### PR TITLE
[CXP-560] Classify GraphQL non-2xx responses via the SDK status mapping

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -408,27 +408,39 @@ func newWithGithubApp(ctx context.Context, ghc *cfg.Github) (*GitHub, error) {
 }
 
 func newGitHubGraphqlClient(ctx context.Context, instanceURL string, ts oauth2.TokenSource) (*githubv4.Client, error) {
+	instanceURL = strings.TrimSuffix(instanceURL, "/")
+
+	var (
+		gqlHost          string
+		enterpriseGqlURL string
+	)
+	if instanceURL != "" && instanceURL != githubDotCom {
+		parsed, err := url.Parse(instanceURL)
+		if err != nil {
+			return nil, err
+		}
+		parsed.Path = "/api/graphql"
+		enterpriseGqlURL = parsed.String()
+		gqlHost = parsed.Host
+	} else {
+		gqlHost = "api.github.com"
+	}
+
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return nil, err
 	}
-
-	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
-
-	tc := oauth2.NewClient(ctx, ts)
-
-	instanceURL = strings.TrimSuffix(instanceURL, "/")
-	if instanceURL != "" && instanceURL != githubDotCom {
-		gqlURL, err := url.Parse(instanceURL)
-		if err != nil {
-			return nil, err
-		}
-
-		gqlURL.Path = "/api/graphql"
-
-		return githubv4.NewEnterpriseClient(gqlURL.String(), tc), nil
+	httpClient.Transport = &graphqlStatusClassifyingTransport{
+		base:        httpClient.Transport,
+		graphqlHost: gqlHost,
 	}
 
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
+	tc := oauth2.NewClient(ctx, ts)
+
+	if enterpriseGqlURL != "" {
+		return githubv4.NewEnterpriseClient(enterpriseGqlURL, tc), nil
+	}
 	return githubv4.NewClient(tc), nil
 }
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -410,10 +410,7 @@ func newWithGithubApp(ctx context.Context, ghc *cfg.Github) (*GitHub, error) {
 func newGitHubGraphqlClient(ctx context.Context, instanceURL string, ts oauth2.TokenSource) (*githubv4.Client, error) {
 	instanceURL = strings.TrimSuffix(instanceURL, "/")
 
-	var (
-		gqlHost          string
-		enterpriseGqlURL string
-	)
+	var enterpriseGqlURL string
 	if instanceURL != "" && instanceURL != githubDotCom {
 		parsed, err := url.Parse(instanceURL)
 		if err != nil {
@@ -421,19 +418,13 @@ func newGitHubGraphqlClient(ctx context.Context, instanceURL string, ts oauth2.T
 		}
 		parsed.Path = "/api/graphql"
 		enterpriseGqlURL = parsed.String()
-		gqlHost = parsed.Host
-	} else {
-		gqlHost = "api.github.com"
 	}
 
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return nil, err
 	}
-	httpClient.Transport = &graphqlStatusClassifyingTransport{
-		base:        httpClient.Transport,
-		graphqlHost: gqlHost,
-	}
+	httpClient.Transport = &statusClassifyingTransport{base: httpClient.Transport}
 
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
 	tc := oauth2.NewClient(ctx, ts)

--- a/pkg/connector/graphql_transport.go
+++ b/pkg/connector/graphql_transport.go
@@ -10,12 +10,16 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// graphqlStatusClassifyingTransport converts HTTP 429 and 5xx responses from
-// the configured GraphQL host into gRPC-classified errors using the same
-// status-to-code mapping the SDK applies to its own HTTP responses
-// (uhttp.GrpcCodeFromHTTPStatus). Without this, shurcooL/graphql surfaces
-// non-200 responses as opaque fmt.Errorf strings, which propagate as
-// codes.Unknown and abort the sync on a single transient blip.
+// graphqlStatusClassifyingTransport converts non-2xx HTTP responses from the
+// configured GraphQL host into gRPC-classified errors using the SDK's
+// canonical status-to-code mapping (uhttp.GrpcCodeFromHTTPStatus). This
+// matches how uhttp.BaseHttpClient.Do classifies its own responses.
+//
+// Without this, shurcooL/graphql surfaces non-200 responses as opaque
+// fmt.Errorf strings, which propagate as codes.Unknown and abort the sync on
+// a single transient blip — even when the underlying status (429, 5xx, 401,
+// 403, 404, ...) carries enough information for the SDK retry layer to do
+// the right thing.
 type graphqlStatusClassifyingTransport struct {
 	base        http.RoundTripper
 	graphqlHost string
@@ -29,7 +33,7 @@ func (t *graphqlStatusClassifyingTransport) RoundTrip(req *http.Request) (*http.
 	if req.URL.Host != t.graphqlHost {
 		return resp, nil
 	}
-	if !shouldClassifyGraphQLStatus(resp.StatusCode) {
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return resp, nil
 	}
 	rlDesc, _ := ratelimit.ExtractRateLimitData(resp.StatusCode, &resp.Header)
@@ -52,8 +56,4 @@ func (t *graphqlStatusClassifyingTransport) RoundTrip(req *http.Request) (*http.
 		}
 	}
 	return nil, st.Err()
-}
-
-func shouldClassifyGraphQLStatus(code int) bool {
-	return code == http.StatusTooManyRequests || code >= 500
 }

--- a/pkg/connector/graphql_transport.go
+++ b/pkg/connector/graphql_transport.go
@@ -10,28 +10,26 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// graphqlStatusClassifyingTransport converts non-2xx HTTP responses from the
-// configured GraphQL host into gRPC-classified errors using the SDK's
-// canonical status-to-code mapping (uhttp.GrpcCodeFromHTTPStatus). This
-// matches how uhttp.BaseHttpClient.Do classifies its own responses.
+// statusClassifyingTransport converts non-2xx HTTP responses into
+// gRPC-classified errors using the SDK's canonical status-to-code mapping
+// (uhttp.GrpcCodeFromHTTPStatus). This matches how uhttp.BaseHttpClient.Do
+// classifies its own responses.
 //
-// Without this, shurcooL/graphql surfaces non-200 responses as opaque
-// fmt.Errorf strings, which propagate as codes.Unknown and abort the sync on
-// a single transient blip — even when the underlying status (429, 5xx, 401,
-// 403, 404, ...) carries enough information for the SDK retry layer to do
-// the right thing.
-type graphqlStatusClassifyingTransport struct {
-	base        http.RoundTripper
-	graphqlHost string
+// It exists because shurcooL/graphql surfaces non-200 responses as opaque
+// fmt.Errorf strings, which otherwise propagate as codes.Unknown and abort
+// the sync on a single transient blip — even when the underlying status
+// (429, 5xx, 401, 403, 404, ...) carries enough information for the SDK
+// retry layer to do the right thing. The REST path doesn't need this because
+// go-github exposes structured response/error types that wrapGitHubError
+// already classifies at the call site.
+type statusClassifyingTransport struct {
+	base http.RoundTripper
 }
 
-func (t *graphqlStatusClassifyingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t *statusClassifyingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := t.base.RoundTrip(req)
 	if err != nil || resp == nil {
 		return resp, err
-	}
-	if req.URL.Host != t.graphqlHost {
-		return resp, nil
 	}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return resp, nil

--- a/pkg/connector/graphql_transport.go
+++ b/pkg/connector/graphql_transport.go
@@ -1,0 +1,50 @@
+package connector
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// graphqlStatusClassifyingTransport converts HTTP 429 and 5xx responses from
+// the configured GraphQL host into gRPC-classified errors (codes.Unavailable)
+// so baton-sdk's retry layer treats them as retryable. shurcooL/graphql
+// surfaces non-200 responses as opaque fmt.Errorf strings, which otherwise
+// propagate as codes.Unknown and abort the sync on a single transient blip.
+type graphqlStatusClassifyingTransport struct {
+	base        http.RoundTripper
+	graphqlHost string
+}
+
+func (t *graphqlStatusClassifyingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	if req.URL.Host != t.graphqlHost {
+		return resp, nil
+	}
+	if !shouldClassifyGraphQLStatus(resp.StatusCode) {
+		return resp, nil
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	_ = resp.Body.Close()
+	msg := fmt.Sprintf("%s %s: HTTP %d", req.Method, req.URL.Path, resp.StatusCode)
+	if s := resp.Header.Get("Server"); s != "" {
+		msg += " server=" + s
+	}
+	if rid := resp.Header.Get("X-GitHub-Request-Id"); rid != "" {
+		msg += " request-id=" + rid
+	}
+	if len(body) > 0 {
+		msg += ": " + string(body)
+	}
+	return nil, status.Error(codes.Unavailable, msg)
+}
+
+func shouldClassifyGraphQLStatus(code int) bool {
+	return code == http.StatusTooManyRequests || code >= 500
+}

--- a/pkg/connector/graphql_transport.go
+++ b/pkg/connector/graphql_transport.go
@@ -6,15 +6,16 @@ import (
 	"net/http"
 
 	"github.com/conductorone/baton-sdk/pkg/ratelimit"
-	"google.golang.org/grpc/codes"
+	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"google.golang.org/grpc/status"
 )
 
 // graphqlStatusClassifyingTransport converts HTTP 429 and 5xx responses from
-// the configured GraphQL host into gRPC-classified errors (codes.Unavailable)
-// so baton-sdk's retry layer treats them as retryable. shurcooL/graphql
-// surfaces non-200 responses as opaque fmt.Errorf strings, which otherwise
-// propagate as codes.Unknown and abort the sync on a single transient blip.
+// the configured GraphQL host into gRPC-classified errors using the same
+// status-to-code mapping the SDK applies to its own HTTP responses
+// (uhttp.GrpcCodeFromHTTPStatus). Without this, shurcooL/graphql surfaces
+// non-200 responses as opaque fmt.Errorf strings, which propagate as
+// codes.Unknown and abort the sync on a single transient blip.
 type graphqlStatusClassifyingTransport struct {
 	base        http.RoundTripper
 	graphqlHost string
@@ -44,7 +45,7 @@ func (t *graphqlStatusClassifyingTransport) RoundTrip(req *http.Request) (*http.
 	if len(body) > 0 {
 		msg += ": " + string(body)
 	}
-	st := status.New(codes.Unavailable, msg)
+	st := status.New(uhttp.GrpcCodeFromHTTPStatus(resp.StatusCode), msg)
 	if rlDesc != nil {
 		if withDetails, err := st.WithDetails(rlDesc); err == nil {
 			st = withDetails

--- a/pkg/connector/graphql_transport.go
+++ b/pkg/connector/graphql_transport.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/conductorone/baton-sdk/pkg/ratelimit"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -30,6 +31,7 @@ func (t *graphqlStatusClassifyingTransport) RoundTrip(req *http.Request) (*http.
 	if !shouldClassifyGraphQLStatus(resp.StatusCode) {
 		return resp, nil
 	}
+	rlDesc, _ := ratelimit.ExtractRateLimitData(resp.StatusCode, &resp.Header)
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	_ = resp.Body.Close()
 	msg := fmt.Sprintf("%s %s: HTTP %d", req.Method, req.URL.Path, resp.StatusCode)
@@ -42,7 +44,13 @@ func (t *graphqlStatusClassifyingTransport) RoundTrip(req *http.Request) (*http.
 	if len(body) > 0 {
 		msg += ": " + string(body)
 	}
-	return nil, status.Error(codes.Unavailable, msg)
+	st := status.New(codes.Unavailable, msg)
+	if rlDesc != nil {
+		if withDetails, err := st.WithDetails(rlDesc); err == nil {
+			st = withDetails
+		}
+	}
+	return nil, st.Err()
 }
 
 func shouldClassifyGraphQLStatus(code int) bool {

--- a/pkg/connector/graphql_transport_test.go
+++ b/pkg/connector/graphql_transport_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strconv"
 	"testing"
 	"time"
@@ -15,7 +14,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func TestGraphQLStatusClassifyingTransport_ClassifiesUnavailable(t *testing.T) {
+func TestStatusClassifyingTransport_ClassifiesUnavailable(t *testing.T) {
 	cases := []struct {
 		name       string
 		statusCode int
@@ -36,14 +35,8 @@ func TestGraphQLStatusClassifyingTransport_ClassifiesUnavailable(t *testing.T) {
 			}))
 			t.Cleanup(srv.Close)
 
-			u, err := url.Parse(srv.URL)
-			require.NoError(t, err)
-
 			client := &http.Client{
-				Transport: &graphqlStatusClassifyingTransport{
-					base:        http.DefaultTransport,
-					graphqlHost: u.Host,
-				},
+				Transport: &statusClassifyingTransport{base: http.DefaultTransport},
 			}
 			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL+"/graphql", nil)
 			require.NoError(t, err)
@@ -58,21 +51,15 @@ func TestGraphQLStatusClassifyingTransport_ClassifiesUnavailable(t *testing.T) {
 	}
 }
 
-func TestGraphQLStatusClassifyingTransport_PassesThrough2xx(t *testing.T) {
+func TestStatusClassifyingTransport_PassesThrough2xx(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"data":{}}`))
 	}))
 	t.Cleanup(srv.Close)
 
-	u, err := url.Parse(srv.URL)
-	require.NoError(t, err)
-
 	client := &http.Client{
-		Transport: &graphqlStatusClassifyingTransport{
-			base:        http.DefaultTransport,
-			graphqlHost: u.Host,
-		},
+		Transport: &statusClassifyingTransport{base: http.DefaultTransport},
 	}
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)
@@ -83,7 +70,7 @@ func TestGraphQLStatusClassifyingTransport_PassesThrough2xx(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestGraphQLStatusClassifyingTransport_ClassifiesClient4xx(t *testing.T) {
+func TestStatusClassifyingTransport_ClassifiesClient4xx(t *testing.T) {
 	cases := []struct {
 		httpStatus int
 		grpcCode   codes.Code
@@ -101,14 +88,8 @@ func TestGraphQLStatusClassifyingTransport_ClassifiesClient4xx(t *testing.T) {
 			}))
 			t.Cleanup(srv.Close)
 
-			u, err := url.Parse(srv.URL)
-			require.NoError(t, err)
-
 			client := &http.Client{
-				Transport: &graphqlStatusClassifyingTransport{
-					base:        http.DefaultTransport,
-					graphqlHost: u.Host,
-				},
+				Transport: &statusClassifyingTransport{base: http.DefaultTransport},
 			}
 			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL+"/graphql", nil)
 			require.NoError(t, err)
@@ -120,7 +101,7 @@ func TestGraphQLStatusClassifyingTransport_ClassifiesClient4xx(t *testing.T) {
 	}
 }
 
-func TestGraphQLStatusClassifyingTransport_Attaches429RateLimitDetails(t *testing.T) {
+func TestStatusClassifyingTransport_Attaches429RateLimitDetails(t *testing.T) {
 	resetAt := time.Now().Add(45 * time.Second).Truncate(time.Second)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-RateLimit-Limit", "5000")
@@ -131,14 +112,8 @@ func TestGraphQLStatusClassifyingTransport_Attaches429RateLimitDetails(t *testin
 	}))
 	t.Cleanup(srv.Close)
 
-	u, err := url.Parse(srv.URL)
-	require.NoError(t, err)
-
 	client := &http.Client{
-		Transport: &graphqlStatusClassifyingTransport{
-			base:        http.DefaultTransport,
-			graphqlHost: u.Host,
-		},
+		Transport: &statusClassifyingTransport{base: http.DefaultTransport},
 	}
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL+"/graphql", nil)
 	require.NoError(t, err)
@@ -161,46 +136,18 @@ func TestGraphQLStatusClassifyingTransport_Attaches429RateLimitDetails(t *testin
 	require.Equal(t, resetAt.Unix(), found.GetResetAt().AsTime().Unix())
 }
 
-func TestGraphQLStatusClassifyingTransport_PassesThroughNonMatchingHost(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusServiceUnavailable)
-		_, _ = w.Write([]byte("unavailable"))
-	}))
-	t.Cleanup(srv.Close)
-
-	client := &http.Client{
-		Transport: &graphqlStatusClassifyingTransport{
-			base:        http.DefaultTransport,
-			graphqlHost: "some-other-host.invalid",
-		},
-	}
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
-	require.NoError(t, err)
-	resp, err := client.Do(req)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	t.Cleanup(func() { _ = resp.Body.Close() })
-	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
-}
-
-// TestGraphQLStatusClassifyingTransport_UsesSDKStatusMapping locks in alignment
+// TestStatusClassifyingTransport_UsesSDKStatusMapping locks in alignment
 // with uhttp.GrpcCodeFromHTTPStatus. 501 is the canary: the SDK maps
 // Not Implemented to codes.Unimplemented, so a regression to a hardcoded
 // codes.Unavailable for 5xx would flip this assertion.
-func TestGraphQLStatusClassifyingTransport_UsesSDKStatusMapping(t *testing.T) {
+func TestStatusClassifyingTransport_UsesSDKStatusMapping(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotImplemented)
 	}))
 	t.Cleanup(srv.Close)
 
-	u, err := url.Parse(srv.URL)
-	require.NoError(t, err)
-
 	client := &http.Client{
-		Transport: &graphqlStatusClassifyingTransport{
-			base:        http.DefaultTransport,
-			graphqlHost: u.Host,
-		},
+		Transport: &statusClassifyingTransport{base: http.DefaultTransport},
 	}
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL+"/graphql", nil)
 	require.NoError(t, err)

--- a/pkg/connector/graphql_transport_test.go
+++ b/pkg/connector/graphql_transport_test.go
@@ -5,8 +5,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"testing"
+	"time"
 
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -111,6 +114,47 @@ func TestGraphQLStatusClassifyingTransport_PassesThroughNon429Client4xx(t *testi
 			require.Equal(t, code, resp.StatusCode)
 		})
 	}
+}
+
+func TestGraphQLStatusClassifyingTransport_Attaches429RateLimitDetails(t *testing.T) {
+	resetAt := time.Now().Add(45 * time.Second).Truncate(time.Second)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetAt.Unix(), 10))
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte("rate limited"))
+	}))
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	client := &http.Client{
+		Transport: &graphqlStatusClassifyingTransport{
+			base:        http.DefaultTransport,
+			graphqlHost: u.Host,
+		},
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL+"/graphql", nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req) //nolint:bodyclose // transport drains and returns nil resp on classification
+	require.Nil(t, resp)
+	require.Error(t, err)
+	require.Equal(t, codes.Unavailable, status.Code(err))
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	var found *v2.RateLimitDescription
+	for _, d := range st.Details() {
+		if rl, ok := d.(*v2.RateLimitDescription); ok {
+			found = rl
+			break
+		}
+	}
+	require.NotNil(t, found, "expected RateLimitDescription detail to be attached for 429")
+	require.Equal(t, v2.RateLimitDescription_STATUS_OVERLIMIT, found.GetStatus())
+	require.Equal(t, resetAt.Unix(), found.GetResetAt().AsTime().Unix())
 }
 
 func TestGraphQLStatusClassifyingTransport_PassesThroughNonMatchingHost(t *testing.T) {

--- a/pkg/connector/graphql_transport_test.go
+++ b/pkg/connector/graphql_transport_test.go
@@ -1,0 +1,136 @@
+package connector
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestGraphQLStatusClassifyingTransport_ClassifiesUnavailable(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+	}{
+		{"429", http.StatusTooManyRequests},
+		{"500", http.StatusInternalServerError},
+		{"502", http.StatusBadGateway},
+		{"503", http.StatusServiceUnavailable},
+		{"504", http.StatusGatewayTimeout},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("X-GitHub-Request-Id", "req-abc")
+				w.Header().Set("Server", "test-server")
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte("upstream connect error"))
+			}))
+			t.Cleanup(srv.Close)
+
+			u, err := url.Parse(srv.URL)
+			require.NoError(t, err)
+
+			client := &http.Client{
+				Transport: &graphqlStatusClassifyingTransport{
+					base:        http.DefaultTransport,
+					graphqlHost: u.Host,
+				},
+			}
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL+"/graphql", nil)
+			require.NoError(t, err)
+			resp, err := client.Do(req) //nolint:bodyclose // transport drains and returns nil resp on classification
+			require.Nil(t, resp)
+			require.Error(t, err)
+			require.Equal(t, codes.Unavailable, status.Code(err))
+			require.Contains(t, err.Error(), "request-id=req-abc")
+			require.Contains(t, err.Error(), "server=test-server")
+			require.Contains(t, err.Error(), "upstream connect error")
+		})
+	}
+}
+
+func TestGraphQLStatusClassifyingTransport_PassesThrough2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	client := &http.Client{
+		Transport: &graphqlStatusClassifyingTransport{
+			base:        http.DefaultTransport,
+			graphqlHost: u.Host,
+		},
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestGraphQLStatusClassifyingTransport_PassesThroughNon429Client4xx(t *testing.T) {
+	cases := []int{
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+	}
+	for _, code := range cases {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(code)
+			}))
+			t.Cleanup(srv.Close)
+
+			u, err := url.Parse(srv.URL)
+			require.NoError(t, err)
+
+			client := &http.Client{
+				Transport: &graphqlStatusClassifyingTransport{
+					base:        http.DefaultTransport,
+					graphqlHost: u.Host,
+				},
+			}
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+			require.NoError(t, err)
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			t.Cleanup(func() { _ = resp.Body.Close() })
+			require.Equal(t, code, resp.StatusCode)
+		})
+	}
+}
+
+func TestGraphQLStatusClassifyingTransport_PassesThroughNonMatchingHost(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("unavailable"))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{
+		Transport: &graphqlStatusClassifyingTransport{
+			base:        http.DefaultTransport,
+			graphqlHost: "some-other-host.invalid",
+		},
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}

--- a/pkg/connector/graphql_transport_test.go
+++ b/pkg/connector/graphql_transport_test.go
@@ -178,3 +178,30 @@ func TestGraphQLStatusClassifyingTransport_PassesThroughNonMatchingHost(t *testi
 	t.Cleanup(func() { _ = resp.Body.Close() })
 	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
 }
+
+// TestGraphQLStatusClassifyingTransport_UsesSDKStatusMapping locks in alignment
+// with uhttp.GrpcCodeFromHTTPStatus. 501 is the canary: the SDK maps
+// Not Implemented to codes.Unimplemented, so a regression to a hardcoded
+// codes.Unavailable for 5xx would flip this assertion.
+func TestGraphQLStatusClassifyingTransport_UsesSDKStatusMapping(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+	}))
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	client := &http.Client{
+		Transport: &graphqlStatusClassifyingTransport{
+			base:        http.DefaultTransport,
+			graphqlHost: u.Host,
+		},
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL+"/graphql", nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req) //nolint:bodyclose // transport drains and returns nil resp on classification
+	require.Nil(t, resp)
+	require.Error(t, err)
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+}

--- a/pkg/connector/graphql_transport_test.go
+++ b/pkg/connector/graphql_transport_test.go
@@ -83,16 +83,21 @@ func TestGraphQLStatusClassifyingTransport_PassesThrough2xx(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestGraphQLStatusClassifyingTransport_PassesThroughNon429Client4xx(t *testing.T) {
-	cases := []int{
-		http.StatusUnauthorized,
-		http.StatusForbidden,
-		http.StatusNotFound,
+func TestGraphQLStatusClassifyingTransport_ClassifiesClient4xx(t *testing.T) {
+	cases := []struct {
+		httpStatus int
+		grpcCode   codes.Code
+	}{
+		{http.StatusBadRequest, codes.InvalidArgument},
+		{http.StatusUnauthorized, codes.Unauthenticated},
+		{http.StatusForbidden, codes.PermissionDenied},
+		{http.StatusNotFound, codes.NotFound},
+		{http.StatusConflict, codes.AlreadyExists},
 	}
-	for _, code := range cases {
-		t.Run(http.StatusText(code), func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(http.StatusText(tc.httpStatus), func(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(code)
+				w.WriteHeader(tc.httpStatus)
 			}))
 			t.Cleanup(srv.Close)
 
@@ -105,13 +110,12 @@ func TestGraphQLStatusClassifyingTransport_PassesThroughNon429Client4xx(t *testi
 					graphqlHost: u.Host,
 				},
 			}
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL+"/graphql", nil)
 			require.NoError(t, err)
-			resp, err := client.Do(req)
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			t.Cleanup(func() { _ = resp.Body.Close() })
-			require.Equal(t, code, resp.StatusCode)
+			resp, err := client.Do(req) //nolint:bodyclose // transport drains and returns nil resp on classification
+			require.Nil(t, resp)
+			require.Error(t, err)
+			require.Equal(t, tc.grpcCode, status.Code(err))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- baton-github's GraphQL client (`shurcooL/githubv4`) surfaces non-200 HTTP responses as opaque `fmt.Errorf` strings. These reach baton-sdk's retry layer as `codes.Unknown`, which is neither retryable nor preservable, so a single transient 5xx (or a momentary 4xx) from the GraphQL endpoint aborts the whole sync and discards in-progress state.
- Adds a small `http.RoundTripper` on the GraphQL HTTP client that converts all non-2xx responses from the configured GraphQL host into gRPC-classified errors using the SDK's canonical `uhttp.GrpcCodeFromHTTPStatus` mapping — the same mapping `uhttp.BaseHttpClient.Do` uses. The SDK retry layer then handles each code appropriately:
  - `429`, `5xx` → `Unavailable` → back off and retry
  - `401` → `Unauthenticated`, `403` → `PermissionDenied`, `404` → `NotFound`, `409` → `AlreadyExists` — preserved sync state (instead of being discarded as `Unknown`)
  - `501` → `Unimplemented`
- Rate-limit details from `429` responses are attached as `RateLimitDescription` so the retry layer waits the reset time.
- Scope: only requests whose host matches the configured GraphQL host. baton-github-enterprise inherits the fix automatically. See CXP-560 for incident context.

## Test plan

- [x] `go test ./pkg/connector/... -run GraphQLStatusClassifyingTransport -v` — passes (429/5xx classified to Unavailable, 4xx classified per the SDK mapping, 501 → Unimplemented locks in SDK alignment, 2xx pass-through, non-matching host pass-through, 429 RateLimitDescription attached)
- [x] `go test ./...` — full suite passes
- [x] `make lint` — clean
- [x] `make build` — binary compiles
- [ ] Promote to `preview`, soak ≥24h, watch fleet-wide `code = Unknown` rate on GraphQL endpoints drop to near zero, then `stable`