### PR TITLE
Fixes the error matching for determining if an invitation failed due to expiration

### DIFF
--- a/pkg/connector/invitation.go
+++ b/pkg/connector/invitation.go
@@ -32,8 +32,10 @@ const (
 	invitationStatePending = "invitation:pending"
 	invitationStateFailed  = "invitation:failed"
 
-	// GitHub returns the literal string "expired" in failed_reason when an
-	// invitation has expired without being accepted.
+	// GitHub's failed_reason is a free-form sentence, not an enum, so we
+	// substring-match (case-insensitive) for this token to detect
+	// expiration. Observed format on api.github.com today:
+	//   "Invitation expired. User did not accept this invite for 7 days"
 	githubInvitationFailedReasonExpired = "expired"
 
 	// Organization invitations expire 7 days after creation.
@@ -186,13 +188,18 @@ func (i *invitationResourceType) List(ctx context.Context, parentID *v2.Resource
 			return nil, nil, err
 		}
 
+		l := ctxzap.Extract(ctx)
 		invitationResources = make([]*v2.Resource, 0, len(invitations))
 		for _, invitation := range invitations {
 			// The failed_invitations endpoint includes failures other than
 			// expirations (e.g. user_was_inactive, unexpected_failure). Only
 			// surface invitations that explicitly expired.
-			failedReason := strings.ToLower(invitation.GetFailedReason())
-			if !strings.Contains(failedReason, githubInvitationFailedReasonExpired) {
+			failedReason := invitation.GetFailedReason()
+			if !strings.Contains(strings.ToLower(failedReason), githubInvitationFailedReasonExpired) {
+				l.Debug("skipping non-expired failed invitation",
+					zap.Int64("invitation_id", invitation.GetID()),
+					zap.String("failed_reason", failedReason),
+				)
 				continue
 			}
 

--- a/pkg/connector/invitation_test.go
+++ b/pkg/connector/invitation_test.go
@@ -110,8 +110,10 @@ func TestInvitationListPagination(t *testing.T) {
 		},
 	}
 
-	// failedPage1 mixes an actually-expired invitation with one whose
-	// failed_reason is something else; only the expired one should be kept.
+	// failed_reason values match real GitHub output: a free-form sentence,
+	// not an enum. The keep-cases use the actual string observed on
+	// api.github.com plus a casing variant; the drop-cases use values seen
+	// for failures that aren't expirations.
 	failedPage1 := []*github.Invitation{
 		{
 			ID:           github.Ptr(int64(2001)),
@@ -119,7 +121,7 @@ func TestInvitationListPagination(t *testing.T) {
 			Inviter:      &github.User{Login: github.Ptr("admin")},
 			CreatedAt:    &github.Timestamp{Time: pendingCreated1},
 			FailedAt:     &github.Timestamp{Time: expiredFailedAt1},
-			FailedReason: github.Ptr("expired"),
+			FailedReason: github.Ptr("Invitation expired. User did not accept this invite for 7 days"),
 		},
 		{
 			ID:           github.Ptr(int64(2002)),
@@ -137,7 +139,8 @@ func TestInvitationListPagination(t *testing.T) {
 			Inviter:      &github.User{Login: github.Ptr("admin")},
 			CreatedAt:    &github.Timestamp{Time: pendingCreated2},
 			FailedAt:     &github.Timestamp{Time: expiredFailedAt2},
-			FailedReason: github.Ptr("expired"),
+			// Uppercase variant locks in case-insensitive matching.
+			FailedReason: github.Ptr("INVITATION EXPIRED"),
 		},
 		{
 			ID:           github.Ptr(int64(2004)),


### PR DESCRIPTION
the string we were matching on before wasn't correct. This changes the logic to better identify when an invitation fails due to expiration. 