### PR TITLE
docs: update Docker image registry from GHCR to ECR Public

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -423,7 +423,7 @@ spec:
     spec:
       containers:
       - name: baton-github
-        image: ghcr.io/conductorone/baton-github:latest
+        image: public.ecr.aws/conductorone/baton-github:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: BATON_HOST_ID
@@ -468,4 +468,3 @@ If you see this error during sync, it most commonly means the GitHub App is miss
 This permission is required because the connector queries GitHub's GraphQL API to check whether your organization has SAML/SSO configured. GitHub restricts this data to apps with organization admin read access. Without it, the sync will fail.
 
 **To fix:** Go to your GitHub App settings, then navigate to **Permissions** > **Organization permissions** > **Administration** and set it to **Read-only**.
-


### PR DESCRIPTION
## Summary

Connector images are now published exclusively to ECR Public (`public.ecr.aws/conductorone/`). This PR updates `docs/connector.mdx` accordingly.

**Changes made:**
- Updates Docker image reference from `ghcr.io/conductorone/` to `public.ecr.aws/conductorone/`
- Adds `### Resources` section (download center + GitHub repo links) if missing from the self-hosted setup instructions

_This PR was generated automatically._