### PR TITLE
add skip anomaly detection annotation on invitations

### DIFF
--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -66,6 +66,9 @@
           {
             "@type": "type.googleapis.com/c1.connector.v2.V1Identifier",
             "id": "invitation"
+          },
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipSyncAnomalyDetection"
           }
         ]
       },
@@ -74,7 +77,8 @@
         "CAPABILITY_ACCOUNT_PROVISIONING",
         "CAPABILITY_RESOURCE_DELETE"
       ],
-      "permissions": {}
+      "permissions": {},
+      "skipSyncAnomalyDetection": true
     },
     {
       "resourceType": {

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -73,7 +73,9 @@ var (
 		Traits: []v2.ResourceType_Trait{
 			v2.ResourceType_TRAIT_USER,
 		},
-		Annotations: v1AnnotationsForResourceType("invitation"),
+		// Invitations disappear once accepted, so their count can legitimately
+		// drop between syncs. Skip sync anomaly detection for this type only.
+		Annotations: append(v1AnnotationsForResourceType("invitation"), annotations.New(&v2.SkipSyncAnomalyDetection{})...),
 	}
 	resourceTypeApiToken = &v2.ResourceType{
 		Id:          "api-key",


### PR DESCRIPTION
https://github.com/ConductorOne/baton-sdk/pull/926
> Sync anomaly detection flags a sync when a resource type's count drops significantly between syncs. For some resource types this drop is legitimate (e.g. invitations that disappear once accepted). This lets a connector mark such a resource type so anomaly detection ignores drops for it only; all other resource types are still checked.